### PR TITLE
Add dump_to_excel: export API data to Excel workbook

### DIFF
--- a/fastapifromfrictionless/load.py
+++ b/fastapifromfrictionless/load.py
@@ -105,6 +105,60 @@ def create_package(folder: str | os.PathLike, filename: str | os.PathLike, valid
         
     return package
 
+def dump_to_excel(api_url: str, schema_folder: str | os.PathLike, output_filepath: str | os.PathLike):
+    """Fetch all records from each API endpoint and write them to an Excel workbook.
+
+    One sheet per schema, columns ordered to match schema field names.  If an
+    endpoint returns no rows the sheet is still created with the correct headers
+    so the file can be re-ingested by ``update_api_from_package`` without errors.
+
+    Parameters
+    ----------
+    api_url:
+        Base URL of the running FastAPI app (e.g. ``"http://localhost:8000"``).
+    schema_folder:
+        Directory containing ``*.schema.yaml`` files.
+    output_filepath:
+        Destination path for the ``.xlsx`` file.
+    """
+    import frictionless
+    from requests import Session
+
+    schemas = sorted(
+        f for f in os.listdir(schema_folder) if f.endswith("schema.yaml")
+    )
+    session = Session()
+
+    with pd.ExcelWriter(output_filepath) as writer:
+        logger.info(f"Dumping API data to {output_filepath}")
+        for schema_file in schemas:
+            name = schema_file.replace(".schema.yaml", "")
+            endpoint = name.replace("-", "").lower()
+            schema = frictionless.Schema(os.path.join(schema_folder, schema_file))
+            columns = schema.field_names
+
+            logger.info(f"Fetching {endpoint}")
+            try:
+                df = requests_get_all(session, server_url=api_url, endpoint=endpoint)
+            except Exception as e:
+                logger.error(f"Could not fetch {endpoint}: {e}")
+                df = pd.DataFrame(columns=columns)
+
+            # Reorder/filter to match schema column order; fill missing columns with NaN
+            for col in columns:
+                if col not in df.columns:
+                    df[col] = None
+            df = df[columns]
+
+            df.to_excel(writer, sheet_name=name, index=False)
+            logger.info(f"  {len(df)} rows written to sheet '{name}'")
+
+        for sheet in writer.sheets:
+            writer.sheets[sheet].autofit()
+
+    session.close()
+
+
 def get_model(name: str, type: str):
     import models
     from sqlmodel.main import SQLModelMetaclass

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #12: dump_to_excel
+
+Added `dump_to_excel(api_url, schema_folder, output_filepath)` to `load.py`. Fetches all records from each endpoint, reorders columns to match schema field order, handles endpoint errors gracefully (writes empty sheet instead of aborting), and autofits columns. Also created `tests/` with 4 pytest tests covering data rows, empty API, error resilience, and column ordering.
+
+---
+
 ## 2026-05-13 — Issue #10: README rewrite
 
 Rewrote README to replace the rough WIP checklist with a proper package overview, requirements list, Quick Start, and a structured production roadmap (Foundation → Code Quality → Production Readiness → Developer Experience → Optional). Also added CLAUDE.md with the 9-step development workflow and coding guidelines. No code changes.

--- a/tests/test_dump_to_excel.py
+++ b/tests/test_dump_to_excel.py
@@ -1,0 +1,101 @@
+"""Tests for dump_to_excel in load.py."""
+import os
+import textwrap
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from fastapifromfrictionless.load import dump_to_excel
+
+
+@pytest.fixture()
+def schema_folder(tmp_path):
+    """A temporary schema folder with two minimal schemas."""
+    (tmp_path / "location.schema.yaml").write_text(textwrap.dedent("""\
+        fields:
+          - name: address
+            type: string
+          - name: zipcode
+            type: string
+    """))
+    (tmp_path / "sensor.schema.yaml").write_text(textwrap.dedent("""\
+        fields:
+          - name: name
+            type: string
+          - name: model
+            type: string
+    """))
+    return tmp_path
+
+
+def _mock_get_all(df_map):
+    """Return a requests_get_all side_effect that returns per-endpoint DataFrames."""
+    def _inner(session, server_url, endpoint):
+        if endpoint in df_map:
+            return df_map[endpoint]
+        raise RuntimeError(f"Unexpected endpoint: {endpoint}")
+    return _inner
+
+
+@patch("fastapifromfrictionless.load.requests_get_all")
+def test_dump_writes_data_rows(mock_get, schema_folder, tmp_path):
+    mock_get.side_effect = _mock_get_all({
+        "location": pd.DataFrame([{"address": "123 Main St", "zipcode": "43215"}]),
+        "sensor": pd.DataFrame([{"name": "AQ-1", "model": "PurpleAir"}]),
+    })
+    out = tmp_path / "out.xlsx"
+    dump_to_excel("http://localhost:8000", schema_folder, out)
+
+    assert out.exists()
+    sheets = pd.read_excel(out, sheet_name=None)
+    assert set(sheets.keys()) == {"location", "sensor"}
+    assert list(sheets["location"].columns) == ["address", "zipcode"]
+    assert sheets["location"].iloc[0]["address"] == "123 Main St"
+    assert sheets["sensor"].iloc[0]["name"] == "AQ-1"
+
+
+@patch("fastapifromfrictionless.load.requests_get_all")
+def test_dump_empty_api_writes_headers_only(mock_get, schema_folder, tmp_path):
+    mock_get.side_effect = _mock_get_all({
+        "location": pd.DataFrame(columns=["address", "zipcode"]),
+        "sensor": pd.DataFrame(columns=["name", "model"]),
+    })
+    out = tmp_path / "empty.xlsx"
+    dump_to_excel("http://localhost:8000", schema_folder, out)
+
+    sheets = pd.read_excel(out, sheet_name=None)
+    assert list(sheets["location"].columns) == ["address", "zipcode"]
+    assert len(sheets["location"]) == 0
+
+
+@patch("fastapifromfrictionless.load.requests_get_all")
+def test_dump_endpoint_error_writes_empty_sheet(mock_get, schema_folder, tmp_path):
+    """A failing endpoint should not abort the whole export — write an empty sheet."""
+    def _raise(session, server_url, endpoint):
+        if endpoint == "sensor":
+            raise RuntimeError("connection refused")
+        return pd.DataFrame([{"address": "1 Ohio St", "zipcode": "43215"}])
+
+    mock_get.side_effect = _raise
+    out = tmp_path / "partial.xlsx"
+    dump_to_excel("http://localhost:8000", schema_folder, out)
+
+    sheets = pd.read_excel(out, sheet_name=None)
+    assert len(sheets["location"]) == 1
+    assert len(sheets["sensor"]) == 0
+
+
+@patch("fastapifromfrictionless.load.requests_get_all")
+def test_dump_column_order_matches_schema(mock_get, schema_folder, tmp_path):
+    """Columns in the output must follow schema field order, not API response order."""
+    mock_get.side_effect = _mock_get_all({
+        "location": pd.DataFrame([{"zipcode": "43215", "address": "1 Ohio St"}]),
+        "sensor": pd.DataFrame([{"model": "PurpleAir", "name": "AQ-1"}]),
+    })
+    out = tmp_path / "ordered.xlsx"
+    dump_to_excel("http://localhost:8000", schema_folder, out)
+
+    sheets = pd.read_excel(out, sheet_name=None)
+    assert list(sheets["location"].columns) == ["address", "zipcode"]
+    assert list(sheets["sensor"].columns) == ["name", "model"]


### PR DESCRIPTION
## Summary

- Adds `dump_to_excel(api_url, schema_folder, output_filepath)` to `load.py`
- Fetches all records from each schema endpoint, reorders columns to match schema field order, and writes one sheet per schema to an `.xlsx` file
- Errors on a single endpoint write an empty sheet rather than aborting the whole export
- Creates `tests/` with 4 pytest tests (data rows, empty API, error resilience, column ordering)

## Test plan

- [x] `pytest tests/test_dump_to_excel.py` — 4/4 passing

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)