### PR TITLE
Add schema validation before code generation

### DIFF
--- a/fastapifromfrictionless/__init__.py
+++ b/fastapifromfrictionless/__init__.py
@@ -7,4 +7,5 @@ from .app import app
 from .model import models
 from .database import database
 from .load import *
+from .validate import validate_schemas, assert_schemas_valid
 

--- a/fastapifromfrictionless/model.py
+++ b/fastapifromfrictionless/model.py
@@ -7,6 +7,8 @@ logger = logging.getLogger(__name__)
 
 from os import PathLike
 
+from .validate import assert_schemas_valid
+
 type_map = {
     "string": {
         "default": "str",
@@ -97,12 +99,9 @@ class TimestampMixin: # https://www.davidmuraya.com/blog/reusable-sqlmodel-mixin
         sa_type=DateTime(timezone=True)
     )
 """
-        # Validate folder
-        if not os.path.exists(folder):
-            logger.error(f"{folder} not a valid path.")
-        else:
-            self.folder = folder
-        
+        assert_schemas_valid(folder)
+        self.folder = folder
+
         # Read schemas from folder
         self.schemas = [x for x in os.listdir(folder) if x.endswith('schema.yaml')]
         logger.info(f"Building models for schemas from {folder}: {" .".join(self.schemas)}")

--- a/fastapifromfrictionless/validate.py
+++ b/fastapifromfrictionless/validate.py
@@ -1,0 +1,69 @@
+"""Schema validation for fastapifromfrictionless generators."""
+import logging
+import os
+from os import PathLike
+
+import frictionless
+
+logger = logging.getLogger(__name__)
+
+
+def validate_schemas(folder: str | PathLike) -> list[str]:
+    """Check a folder of ``*.schema.yaml`` files for code-generation compatibility.
+
+    Returns a list of human-readable error strings.  An empty list means all
+    schemas are valid.  Does *not* raise — callers decide what to do with errors.
+
+    Checks performed
+    ----------------
+    - Folder exists and contains at least one ``*.schema.yaml``
+    - Each schema file loads without error (frictionless validates types, PKs, etc.)
+    - Foreign key references point to an existing schema in the folder (cross-schema
+      consistency that frictionless cannot verify on its own)
+    """
+    errors: list[str] = []
+
+    if not os.path.isdir(folder):
+        errors.append(f"Schema folder does not exist: {folder!r}")
+        return errors
+
+    schema_files = sorted(f for f in os.listdir(folder) if f.endswith("schema.yaml"))
+    if not schema_files:
+        errors.append(f"No *.schema.yaml files found in {folder!r}")
+        return errors
+
+    known_resources = {f.replace(".schema.yaml", "").lower() for f in schema_files}
+    loaded: dict[str, frictionless.Schema] = {}
+
+    for filename in schema_files:
+        filepath = os.path.join(folder, filename)
+        label = filename
+
+        try:
+            schema = frictionless.Schema(filepath)
+            loaded[filename] = schema
+        except Exception as exc:
+            errors.append(f"[{label}] Failed to load schema: {exc}")
+
+    # Cross-schema FK reference check (only for schemas that loaded successfully)
+    for filename, schema in loaded.items():
+        label = filename
+        for fk in schema.foreign_keys:
+            ref_resource = fk.get("reference", {}).get("resource", "")
+            if ref_resource and ref_resource.lower() not in known_resources:
+                errors.append(
+                    f"[{label}] Foreign key references unknown resource '{ref_resource}'. "
+                    f"Known resources: {sorted(known_resources)}"
+                )
+
+    return errors
+
+
+def assert_schemas_valid(folder: str | PathLike) -> None:
+    """Validate schemas and raise ``ValueError`` listing all problems if any are found."""
+    errors = validate_schemas(folder)
+    if errors:
+        msg = f"Schema validation failed for {folder!r} with {len(errors)} error(s):\n"
+        msg += "\n".join(f"  • {e}" for e in errors)
+        raise ValueError(msg)
+    logger.info(f"All schemas in {folder!r} passed validation.")

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #14: Schema validation before code generation
+
+Added `fastapifromfrictionless/validate.py` with `validate_schemas(folder)` and `assert_schemas_valid(folder)`. Validation checks: folder exists and contains schemas, each schema loads cleanly via frictionless (which catches bad types and PK mismatches), and FK references point to known schemas in the same folder. `assert_schemas_valid` is called in `models.__init__` so bad schemas raise `ValueError` with a full error list before any code is generated. Exported both functions from `__init__.py`. 10 pytest tests all passing.
+
+---
+
 ## 2026-05-13 — Issue #10: README rewrite
 
 Rewrote README to replace the rough WIP checklist with a proper package overview, requirements list, Quick Start, and a structured production roadmap (Foundation → Code Quality → Production Readiness → Developer Experience → Optional). Also added CLAUDE.md with the 9-step development workflow and coding guidelines. No code changes.

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,165 @@
+"""Tests for validate.py schema validation."""
+import textwrap
+
+import pytest
+
+from fastapifromfrictionless.validate import assert_schemas_valid, validate_schemas
+
+
+def write_schema(tmp_path, name, content):
+    (tmp_path / f"{name}.schema.yaml").write_text(textwrap.dedent(content))
+
+
+# ---------------------------------------------------------------------------
+# validate_schemas — returns errors, never raises
+# ---------------------------------------------------------------------------
+
+def test_missing_folder_returns_error():
+    errors = validate_schemas("/nonexistent/path/xyz")
+    assert any("does not exist" in e for e in errors)
+
+
+def test_empty_folder_returns_error(tmp_path):
+    errors = validate_schemas(tmp_path)
+    assert any("No *.schema.yaml" in e for e in errors)
+
+
+def test_valid_schema_returns_no_errors(tmp_path):
+    write_schema(tmp_path, "location", """\
+        fields:
+          - name: id
+            type: integer
+          - name: address
+            type: string
+            constraints:
+              required: true
+        primaryKey:
+          - id
+    """)
+    assert validate_schemas(tmp_path) == []
+
+
+def test_unsupported_field_type_returns_error(tmp_path):
+    """Frictionless rejects unknown types at load time; error surfaces via load failure."""
+    write_schema(tmp_path, "item", """\
+        fields:
+          - name: id
+            type: integer
+          - name: coords
+            type: wkt
+    """)
+    errors = validate_schemas(tmp_path)
+    assert len(errors) == 1
+    assert "Failed to load schema" in errors[0]
+    assert "wkt" in errors[0]
+
+
+def test_missing_primary_key_field_returns_error(tmp_path):
+    """Frictionless rejects PKs that don't match defined fields at load time."""
+    write_schema(tmp_path, "item", """\
+        fields:
+          - name: name
+            type: string
+        primaryKey:
+          - ghost_field
+    """)
+    errors = validate_schemas(tmp_path)
+    assert len(errors) == 1
+    assert "Failed to load schema" in errors[0]
+    assert "ghost_field" in errors[0]
+
+
+def test_foreign_key_to_unknown_resource_returns_error(tmp_path):
+    write_schema(tmp_path, "deployment", """\
+        fields:
+          - name: id
+            type: integer
+          - name: location_id
+            type: integer
+        primaryKey:
+          - id
+        foreignKeys:
+          - fields: [location_id]
+            reference:
+              resource: nonexistent
+              fields: [id]
+    """)
+    errors = validate_schemas(tmp_path)
+    assert any("nonexistent" in e and "unknown resource" in e for e in errors)
+
+
+def test_foreign_key_to_known_resource_passes(tmp_path):
+    write_schema(tmp_path, "location", """\
+        fields:
+          - name: id
+            type: integer
+        primaryKey:
+          - id
+    """)
+    write_schema(tmp_path, "deployment", """\
+        fields:
+          - name: id
+            type: integer
+          - name: location_id
+            type: integer
+        primaryKey:
+          - id
+        foreignKeys:
+          - fields: [location_id]
+            reference:
+              resource: location
+              fields: [id]
+    """)
+    assert validate_schemas(tmp_path) == []
+
+
+def test_errors_collected_across_all_schemas(tmp_path):
+    """All schemas are checked; a broken schema doesn't abort the rest."""
+    write_schema(tmp_path, "good", """\
+        fields:
+          - name: id
+            type: integer
+        primaryKey:
+          - id
+    """)
+    write_schema(tmp_path, "bad_a", """\
+        fields:
+          - name: x
+            type: wkt
+    """)
+    write_schema(tmp_path, "bad_b", """\
+        fields:
+          - name: x
+            type: blob
+    """)
+    errors = validate_schemas(tmp_path)
+    # Two load failures, one per bad schema
+    assert len(errors) == 2
+    labels = [e.split("]")[0].lstrip("[") for e in errors]
+    assert "bad_a.schema.yaml" in labels
+    assert "bad_b.schema.yaml" in labels
+
+
+# ---------------------------------------------------------------------------
+# assert_schemas_valid — raises ValueError on failure
+# ---------------------------------------------------------------------------
+
+def test_assert_raises_on_invalid(tmp_path):
+    write_schema(tmp_path, "bad", """\
+        fields:
+          - name: x
+            type: wkt
+    """)
+    with pytest.raises(ValueError, match="Schema validation failed"):
+        assert_schemas_valid(tmp_path)
+
+
+def test_assert_passes_on_valid(tmp_path):
+    write_schema(tmp_path, "good", """\
+        fields:
+          - name: id
+            type: integer
+        primaryKey:
+          - id
+    """)
+    assert_schemas_valid(tmp_path)  # should not raise


### PR DESCRIPTION
## Summary

- Adds `fastapifromfrictionless/validate.py` with two public functions:
  - `validate_schemas(folder)` — returns a list of error strings without raising
  - `assert_schemas_valid(folder)` — raises `ValueError` listing all problems
- Validation checks: folder exists, contains schemas, each schema loads cleanly (frictionless catches bad field types and PK mismatches), and FK references point to known schemas in the same folder
- `assert_schemas_valid` is now called in `models.__init__` so bad schemas fail immediately with a clear message before any code is generated
- Both functions exported from the package `__init__.py`

## Test plan

- [x] `pytest tests/test_validate.py` — 10/10 passing

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)