### PR TITLE
Add unit tests for models, app, and database generators

### DIFF
--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #16: Generator unit tests
+
+Added 30 pytest tests across three files covering the models, app, and database generators. Tests operate on generated source strings (no code execution) using minimal inline `tmp_path` fixtures. Discovered and worked around a PosixPath vs str bug in the generators' logger initialization — generators must be passed `str` paths, not `pathlib.Path`. All 30 tests pass.
+
+---
+
 ## 2026-05-13 — Issue #10: README rewrite
 
 Rewrote README to replace the rough WIP checklist with a proper package overview, requirements list, Quick Start, and a structured production roadmap (Foundation → Code Quality → Production Readiness → Developer Experience → Optional). Also added CLAUDE.md with the 9-step development workflow and coding guidelines. No code changes.

--- a/tests/test_app_generator.py
+++ b/tests/test_app_generator.py
@@ -1,0 +1,137 @@
+"""Unit tests for the app (FastAPI endpoint) code generator."""
+import textwrap
+
+import pytest
+
+from fastapifromfrictionless import app
+
+
+def write_schema(tmp_path, name, content):
+    (tmp_path / f"{name}.schema.yaml").write_text(textwrap.dedent(content))
+
+
+@pytest.fixture()
+def simple_folder(tmp_path):
+    write_schema(tmp_path, "location", """\
+        fields:
+          - name: id
+            type: integer
+          - name: address
+            type: string
+        primaryKey:
+          - id
+    """)
+    return tmp_path
+
+
+@pytest.fixture()
+def fk_folder(tmp_path):
+    write_schema(tmp_path, "sensor", """\
+        fields:
+          - name: id
+            type: integer
+          - name: name
+            type: string
+        primaryKey:
+          - id
+    """)
+    write_schema(tmp_path, "deployment", """\
+        fields:
+          - name: id
+            type: integer
+          - name: sensor_id
+            type: integer
+        primaryKey:
+          - id
+        foreignKeys:
+          - fields: [sensor_id]
+            reference:
+              resource: sensor
+              fields: [id]
+    """)
+    return tmp_path
+
+
+def _output(folder):
+    a = app(str(folder)).build()
+    return "".join(a.endpoints)
+
+
+# ---------------------------------------------------------------------------
+# CRUD routes present
+# ---------------------------------------------------------------------------
+
+def test_post_route_generated(simple_folder):
+    out = _output(simple_folder)
+    assert "@app.post('/location'" in out
+
+
+def test_get_all_route_generated(simple_folder):
+    out = _output(simple_folder)
+    assert "@app.get('/location/all'" in out
+
+
+def test_get_single_route_generated(simple_folder):
+    out = _output(simple_folder)
+    assert "@app.get('/location/{location_id}'" in out
+
+
+def test_patch_route_generated(simple_folder):
+    out = _output(simple_folder)
+    assert "@app.patch('/location/{location_id}'" in out
+
+
+def test_delete_route_generated(simple_folder):
+    out = _output(simple_folder)
+    assert "@app.delete('/location/{location_id}'" in out
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+def test_create_uses_public_response_model(simple_folder):
+    out = _output(simple_folder)
+    assert "response_model=LocationPublic" in out
+
+
+def test_get_all_uses_list_response_model(simple_folder):
+    out = _output(simple_folder)
+    assert "response_model=list[LocationPublic]" in out
+
+
+# ---------------------------------------------------------------------------
+# Query route only when FK present
+# ---------------------------------------------------------------------------
+
+def test_no_query_route_without_fk(simple_folder):
+    out = _output(simple_folder)
+    assert "query_location" not in out
+
+
+def test_query_route_generated_with_fk(fk_folder):
+    out = _output(fk_folder)
+    assert "query_deployment" in out
+
+
+# ---------------------------------------------------------------------------
+# Multiple schemas
+# ---------------------------------------------------------------------------
+
+def test_all_schemas_get_endpoints(fk_folder):
+    out = _output(fk_folder)
+    assert "/sensor" in out
+    assert "/deployment" in out
+
+
+# ---------------------------------------------------------------------------
+# save()
+# ---------------------------------------------------------------------------
+
+def test_save_writes_file(simple_folder, tmp_path):
+    out = tmp_path / "app.py"
+    app(str(simple_folder)).build().save(out)
+    assert out.exists()
+    content = out.read_text()
+    assert "FastAPI" in content
+    assert "create_location" in content

--- a/tests/test_database_generator.py
+++ b/tests/test_database_generator.py
@@ -1,0 +1,45 @@
+"""Unit tests for the database.py code generator."""
+import pytest
+
+from fastapifromfrictionless import database
+
+
+@pytest.fixture()
+def folder(tmp_path):
+    return tmp_path
+
+
+def test_build_returns_self(folder):
+    db = database(str(folder))
+    result = db.build("test.db")
+    assert result is db
+
+
+def test_output_contains_db_filename(folder):
+    db = database(str(folder)).build("my_app.db")
+    assert "my_app.db" in db.database
+
+
+def test_output_contains_sqlite_url(folder):
+    db = database(str(folder)).build("app.db")
+    assert "sqlite:///" in db.database
+
+
+def test_output_contains_engine_creation(folder):
+    db = database(str(folder)).build("app.db")
+    assert "create_engine" in db.database
+
+
+def test_output_contains_create_db_function(folder):
+    db = database(str(folder)).build("app.db")
+    assert "def create_db_and_tables()" in db.database
+    assert "SQLModel.metadata.create_all(engine)" in db.database
+
+
+def test_save_writes_file(folder, tmp_path):
+    out = tmp_path / "database.py"
+    database(str(folder)).build("app.db").save(out)
+    assert out.exists()
+    content = out.read_text()
+    assert "create_engine" in content
+    assert "app.db" in content

--- a/tests/test_models_generator.py
+++ b/tests/test_models_generator.py
@@ -1,0 +1,185 @@
+"""Unit tests for the models code generator."""
+import textwrap
+
+import pytest
+
+from fastapifromfrictionless import models
+
+
+def write_schema(tmp_path, name, content):
+    (tmp_path / f"{name}.schema.yaml").write_text(textwrap.dedent(content))
+
+
+def folder_str(p):
+    """Generators pass folder to logging.getChild, which requires str not PosixPath."""
+    return str(p)
+
+
+@pytest.fixture()
+def simple_folder(tmp_path):
+    write_schema(tmp_path, "location", """\
+        fields:
+          - name: address
+            type: string
+            constraints:
+              required: true
+          - name: zipcode
+            type: integer
+        primaryKey:
+          - address
+    """)
+    return tmp_path
+
+
+@pytest.fixture()
+def id_pk_folder(tmp_path):
+    write_schema(tmp_path, "sensor", """\
+        fields:
+          - name: id
+            type: integer
+          - name: name
+            type: string
+            constraints:
+              required: true
+        primaryKey:
+          - id
+    """)
+    return tmp_path
+
+
+@pytest.fixture()
+def fk_folder(tmp_path):
+    write_schema(tmp_path, "sensor", """\
+        fields:
+          - name: id
+            type: integer
+          - name: name
+            type: string
+            constraints:
+              required: true
+        primaryKey:
+          - id
+    """)
+    write_schema(tmp_path, "deployment", """\
+        fields:
+          - name: id
+            type: integer
+          - name: sensor_id
+            type: integer
+            constraints:
+              required: true
+        primaryKey:
+          - id
+        foreignKeys:
+          - fields: [sensor_id]
+            reference:
+              resource: sensor
+              fields: [id]
+    """)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Class name generation
+# ---------------------------------------------------------------------------
+
+def test_generates_all_six_model_classes(simple_folder):
+    output = "".join(models(folder_str(simple_folder)).build().models)
+    assert "class LocationBase(SQLModel)" in output
+    assert "class Location(LocationBase" in output
+    assert "class LocationCreate(LocationBase)" in output
+    assert "class LocationUpdate(LocationBase)" in output
+    assert "class LocationPublic(LocationBase)" in output
+
+
+def test_no_public_with_all_when_no_relationships(simple_folder):
+    output = "".join(models(folder_str(simple_folder)).build().models)
+    assert "LocationPublicWithAll" not in output
+
+
+# ---------------------------------------------------------------------------
+# Field optionality
+# ---------------------------------------------------------------------------
+
+def test_required_field_is_not_optional(simple_folder):
+    output = "".join(models(folder_str(simple_folder)).build().models)
+    # In the Base class, `address` is required and should appear as `str` (not optional).
+    # The Update model intentionally makes all fields optional, so only check the Base block.
+    base_block = output.split("class LocationBase")[1].split("class Location(")[0]
+    assert "address: str" in base_block
+    assert "address: str | None" not in base_block
+
+
+def test_optional_field_is_none_union(simple_folder):
+    output = "".join(models(folder_str(simple_folder)).build().models)
+    assert "zipcode: int | None" in output
+
+
+# ---------------------------------------------------------------------------
+# Auto-increment id primary key
+# ---------------------------------------------------------------------------
+
+def test_id_pk_excluded_from_base(id_pk_folder):
+    output = "".join(models(str(id_pk_folder)).build().models)
+    # id should NOT appear in SensorBase
+    base_block = output.split("class SensorBase")[1].split("class Sensor(")[0]
+    assert "id" not in base_block
+
+
+def test_id_pk_added_to_table_model(id_pk_folder):
+    output = "".join(models(str(id_pk_folder)).build().models)
+    assert "id: int | None = Field(default=None, primary_key=True)" in output
+
+
+def test_id_included_in_public_model(id_pk_folder):
+    output = "".join(models(str(id_pk_folder)).build().models)
+    public_block = output.split("class SensorPublic")[1].split("class Sensor")[0]
+    assert "id: int" in public_block
+
+
+# ---------------------------------------------------------------------------
+# Foreign keys and relationships
+# ---------------------------------------------------------------------------
+
+def test_fk_field_has_foreign_key_annotation(fk_folder):
+    output = "".join(models(str(fk_folder)).build().models)
+    assert "foreign_key='sensor.id'" in output
+
+
+def test_relationship_added_to_table_model(fk_folder):
+    output = "".join(models(str(fk_folder)).build().models)
+    assert "Relationship(back_populates=" in output
+
+
+def test_public_with_all_generated_when_relationships_exist(fk_folder):
+    output = "".join(models(str(fk_folder)).build().models)
+    assert "SensorPublicWithAll" in output
+    assert "DeploymentPublicWithAll" in output
+
+
+# ---------------------------------------------------------------------------
+# Timestamp mixin
+# ---------------------------------------------------------------------------
+
+def test_table_model_includes_timestamp_mixin(simple_folder):
+    output = "".join(models(folder_str(simple_folder)).build().models)
+    assert "TimestampMixin" in output
+
+
+def test_public_model_includes_timestamps(simple_folder):
+    output = "".join(models(folder_str(simple_folder)).build().models)
+    assert "created_at: datetime" in output
+    assert "updated_at: datetime" in output
+
+
+# ---------------------------------------------------------------------------
+# save()
+# ---------------------------------------------------------------------------
+
+def test_save_writes_file(simple_folder, tmp_path):
+    out = tmp_path / "models.py"
+    models(folder_str(simple_folder)).build().save(out)
+    assert out.exists()
+    content = out.read_text()
+    assert "LocationBase" in content
+    assert "from sqlmodel import" in content


### PR DESCRIPTION
## Summary

- `tests/test_models_generator.py` (13 tests) — class name generation, field optionality, auto-increment id PK, FK annotations, relationships, timestamp mixin, save()
- `tests/test_app_generator.py` (11 tests) — all 5 CRUD routes, response models, query route only when FK present, multi-schema, save()
- `tests/test_database_generator.py` (6 tests) — db filename injection, sqlite URL, engine creation, `create_db_and_tables`, save()

All tests operate on generated source strings without executing the generated code. Inline `tmp_path` fixtures keep tests self-contained and fast.

**Note:** generators must receive `str` paths, not `pathlib.Path` objects, due to a `logging.getChild` call that requires str. This is a latent bug surfaced by testing.

## Test plan

- [x] `pytest tests/test_models_generator.py tests/test_app_generator.py tests/test_database_generator.py` — 30/30 passing

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)