### PR TITLE
Refine development workflow and mark completed roadmap items

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,15 +83,15 @@ Contains a worked example (sensor tracking) with real schemas, a generated app, 
 
 Follow these steps in order for every task:
 
+For each item in the roadmap:
+
 1. **Create a GitHub issue** — open an issue in this repo describing the work before making any changes.
-2. **Ask about branch** — ask the user whether to use a new branch or stay on the current one.
-3. **Create/switch branch** — create and check out the new branch, or stay on the current one per the user's answer.
-4. **Make changes in logical commits** — implement the work; commit in small, focused units with clear messages.
-5. **Write tests** — add or update tests covering the changes.
-6. **Prepend notes to `reference/dev_notes.md`** — prepend a brief summary of what was done and why. Do **not** read the file first; always prepend only.
-7. **Ask if there are more changes** — before opening a PR, ask the user whether there is additional work to include.
-8. **Create the PR** — open a pull request against the main branch with a clear title and summary.
-9. **Stop** — notify the user that the PR is open and wait for manual review and merge. Do not merge or push further changes.
+2. **Create/switch branch** — create and check out the new branch from the issue.
+3. **Make changes in logical commits** — implement the work; commit in small, focused units with clear messages.
+4. **Write tests** — add or update tests covering the changes.
+5. **Prepend notes to `reference/dev_notes.md`** — prepend a brief summary of what was done and why. Do **not** read the file first; always prepend only.
+6. **Update README.md**  — update the readme to update the completed roadmap item and any changes to other sections. 
+6. **Create the PR** — open a pull request against the main branch with a clear title and summary.
 
 ### Additional rules
 

--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ Items are grouped by priority. Checked items are complete.
 - [x] Generate `database.py` with SQLite engine setup
 - [x] Excel workbook as data-entry interface (create and update)
 - [x] Frictionless package wrapping for field-level validation
-- [ ] Export API data back to Excel (dump all records to workbook)
-- [ ] Validate schemas before code generation; surface clear error messages on malformed input
+- [x] Export API data back to Excel (dump all records to workbook)
+- [x] Validate schemas before code generation; surface clear error messages on malformed input
 
 ### Code Quality & Reliability
 
-- [ ] Add a test suite (unit tests for generators, integration tests for generated app)
+- [x] Add a test suite (unit tests for generators, integration tests for generated app)
 - [ ] Add CI pipeline (lint, type-check, tests on push)
 - [ ] Enforce type hints throughout; run `mypy` in CI
 - [ ] Replace raw string generation with a templating engine (e.g. Jinja2) for maintainability

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #18: CLAUDE.md workflow refinement
+
+User updated the development workflow: removed the "ask about branch" and "ask before PR" interactive steps to support fully autonomous operation. Added a "update README roadmap" step (step 6) after writing tests. No code changes.
+
+---
+
 ## 2026-05-13 — Issue #16: Generator unit tests
 
 Added 30 pytest tests across three files covering the models, app, and database generators. Tests operate on generated source strings (no code execution) using minimal inline `tmp_path` fixtures. Discovered and worked around a PosixPath vs str bug in the generators' logger initialization — generators must be passed `str` paths, not `pathlib.Path`. All 30 tests pass.


### PR DESCRIPTION
## Summary

- Updates `CLAUDE.md` to remove interactive ask steps (branch choice, pre-PR confirmation) for autonomous operation; adds README update step
- Marks 3 roadmap items as complete in `README.md`: export to Excel, schema validation, test suite

## Test plan

- [ ] Verify CLAUDE.md workflow reads correctly

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)