### PR TITLE
Add configure_logging: structured logging with configurable verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Items are grouped by priority. Checked items are complete.
 - [x] Add CI pipeline (lint, type-check, tests on push)
 - [x] Enforce type hints throughout; run `mypy` in CI
 - [ ] Replace raw string generation with a templating engine (e.g. Jinja2) for maintainability
-- [ ] Structured logging with configurable verbosity
+- [x] Structured logging with configurable verbosity
 
 ### Production Readiness
 

--- a/fastapifromfrictionless/__init__.py
+++ b/fastapifromfrictionless/__init__.py
@@ -7,5 +7,6 @@ logger = logging.getLogger(__name__)
 from .app import app
 from .database import database
 from .load import *
+from .logging_config import configure_logging
 from .model import models
 from .validate import assert_schemas_valid, validate_schemas

--- a/fastapifromfrictionless/logging_config.py
+++ b/fastapifromfrictionless/logging_config.py
@@ -1,0 +1,59 @@
+"""Logging configuration for fastapifromfrictionless."""
+
+import logging
+import sys
+
+_DEFAULT_FMT = "%(asctime)s %(levelname)-8s %(name)s — %(message)s"
+_DEFAULT_DATEFMT = "%Y-%m-%d %H:%M:%S"
+
+_LEVELS = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "CRITICAL": logging.CRITICAL,
+}
+
+
+def configure_logging(
+    level: str | int = "INFO",
+    fmt: str = _DEFAULT_FMT,
+    datefmt: str = _DEFAULT_DATEFMT,
+) -> None:
+    """Configure logging for the fastapifromfrictionless package.
+
+    Sets up a StreamHandler on the package root logger so callers do not need
+    to configure logging themselves.  Safe to call multiple times — existing
+    handlers on the package logger are replaced each call.
+
+    Parameters
+    ----------
+    level:
+        Log level name (``"DEBUG"``, ``"INFO"``, ``"WARNING"``, ``"ERROR"``) or
+        an integer constant from the ``logging`` module.  Defaults to ``"INFO"``.
+    fmt:
+        Log record format string passed to ``logging.Formatter``.
+    datefmt:
+        Date format string passed to ``logging.Formatter``.
+    """
+    if isinstance(level, str):
+        numeric = _LEVELS.get(level.upper())
+        if numeric is None:
+            raise ValueError(f"Unknown log level {level!r}. Choose from: {list(_LEVELS)}")
+    else:
+        numeric = level
+
+    pkg_logger = logging.getLogger("fastapifromfrictionless")
+    pkg_logger.setLevel(numeric)
+
+    # Replace existing handlers to avoid duplicate output on repeated calls
+    pkg_logger.handlers.clear()
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setLevel(numeric)
+    handler.setFormatter(logging.Formatter(fmt=fmt, datefmt=datefmt))
+    pkg_logger.addHandler(handler)
+
+    # Prevent log records from bubbling to the root logger if it has its own
+    # handlers (avoids duplicate output in applications that configure root).
+    pkg_logger.propagate = False

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #24: Structured logging
+
+Added `fastapifromfrictionless/logging_config.py` with `configure_logging(level, fmt, datefmt)`. Sets level on the package root logger, attaches a single StreamHandler with timestamp+level+name+message format, clears existing handlers on repeated calls, and disables propagation to the root logger. Exported from `__init__`. 8 pytest tests covering level-setting, handler count, repeated calls, propagation, invalid levels, and case-insensitive parsing.
+
+---
+
 ## 2026-05-13 — Issue #22: Type hints and mypy
 
 Fixed 19 mypy errors across the package: (1) renamed loop variable `field` to `field_name` in `model.py` to avoid shadowing between `str` and `frictionless.Field` types; (2) annotated `basemodel_fields: list[str]` explicitly; (3) cast `PathLike` to `str` in `logging.getChild()` calls in `model.py` and `app.py`; (4) stored `self.folder` as `str` in both generators; (5) replaced `filename.split(".")` with `pathlib.Path(filename).stem` in `load.py`. Added `[tool.mypy]` config to `pyproject.toml`, `mypy` to `[dev]` extras, and a mypy step to the CI workflow. Also fixed 51 ruff issues and reformatted all source files. mypy and all 44 tests clean.

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,61 @@
+"""Tests for configure_logging."""
+
+import logging
+
+import pytest
+
+from fastapifromfrictionless.logging_config import configure_logging
+
+PKG = "fastapifromfrictionless"
+
+
+def teardown_function():
+    """Reset the package logger after each test."""
+    pkg = logging.getLogger(PKG)
+    pkg.handlers.clear()
+    pkg.setLevel(logging.WARNING)
+    pkg.propagate = True
+
+
+def test_sets_info_level_by_default():
+    configure_logging()
+    assert logging.getLogger(PKG).level == logging.INFO
+
+
+def test_sets_debug_level():
+    configure_logging("DEBUG")
+    assert logging.getLogger(PKG).level == logging.DEBUG
+
+
+def test_sets_level_by_integer():
+    configure_logging(logging.ERROR)
+    assert logging.getLogger(PKG).level == logging.ERROR
+
+
+def test_adds_stream_handler():
+    configure_logging()
+    handlers = logging.getLogger(PKG).handlers
+    assert len(handlers) == 1
+    assert isinstance(handlers[0], logging.StreamHandler)
+
+
+def test_repeated_calls_replace_handler():
+    configure_logging("DEBUG")
+    configure_logging("INFO")
+    assert len(logging.getLogger(PKG).handlers) == 1
+    assert logging.getLogger(PKG).level == logging.INFO
+
+
+def test_propagate_disabled():
+    configure_logging()
+    assert logging.getLogger(PKG).propagate is False
+
+
+def test_invalid_level_raises():
+    with pytest.raises(ValueError, match="Unknown log level"):
+        configure_logging("VERBOSE")
+
+
+def test_case_insensitive_level():
+    configure_logging("debug")
+    assert logging.getLogger(PKG).level == logging.DEBUG


### PR DESCRIPTION
## Summary

- Adds `fastapifromfrictionless/logging_config.py` with `configure_logging(level, fmt, datefmt)`
- Configures the package root logger with a `StreamHandler` using format: `timestamp levelname logger — message`
- Clears existing handlers on repeated calls (safe to call multiple times)
- Disables propagation to root logger to avoid duplicate output
- Exported from package `__init__` as `from fastapifromfrictionless import configure_logging`

**Usage:**
```python
from fastapifromfrictionless import configure_logging
configure_logging("DEBUG")   # see per-field and per-row detail
configure_logging("INFO")    # default — progress messages only
```

## Test plan

- [x] `pytest tests/test_logging_config.py` — 8/8 passing
- [x] `pytest tests/` — 52/52 passing
- [x] `ruff check` and `mypy` — clean

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)