### PR TITLE
Replace f-string generation with Jinja2 templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Items are grouped by priority. Checked items are complete.
 - [x] Add a test suite (unit tests for generators, integration tests for generated app)
 - [x] Add CI pipeline (lint, type-check, tests on push)
 - [x] Enforce type hints throughout; run `mypy` in CI
-- [ ] Replace raw string generation with a templating engine (e.g. Jinja2) for maintainability
+- [x] Replace raw string generation with a templating engine (e.g. Jinja2) for maintainability
 - [ ] Structured logging with configurable verbosity
 
 ### Production Readiness

--- a/fastapifromfrictionless/app.py
+++ b/fastapifromfrictionless/app.py
@@ -1,7 +1,25 @@
 import logging
 import os
+from pathlib import Path
+
+import jinja2
 
 logger = logging.getLogger(__name__)
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+_env = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(str(_TEMPLATES_DIR)),
+    variable_start_string="<<",
+    variable_end_string=">>",
+    block_start_string="<%",
+    block_end_string="%>",
+    comment_start_string="<#",
+    comment_end_string="#>",
+    trim_blocks=True,
+    lstrip_blocks=True,
+    keep_trailing_newline=True,
+)
 
 
 class app:
@@ -17,10 +35,6 @@ class app:
             The location of the schema files
 
         """
-        import os
-
-        import frictionless
-
         self.logger = (
             logging.getLogger(__name__).getChild(self.__class__.__name__).getChild(str(folder))
         )
@@ -30,34 +44,6 @@ class app:
             raise ValueError
         else:
             self.folder: str = str(folder)
-
-        self.header = """
-# app.py
-from fastapi import Depends, FastAPI, HTTPException, Query
-import fastapi
-from fastapi_querybuilder import QueryBuilder
-from sqlalchemy import text
-from sqlmodel import Session, select
-from .database import create_db_and_tables, engine
-from .models import *
-from sqlalchemy.ext.asyncio import AsyncSession
-
-# Initiate app
-app = FastAPI()
-
-# Dependencies
-@app.on_event('startup')
-def on_startup():
-    create_db_and_tables()
-
-def get_session():
-    with Session(engine) as session:
-        yield session
-
-# @app.get('/')
-# def read_schema(*, session: Session = Depends(get_session)):
-#     return {name.lower()}s
-"""
 
         self.schema_paths = [x for x in os.listdir(folder) if x.endswith("schema.yaml")]
 
@@ -89,75 +75,25 @@ def get_session():
                         if fk["reference"]["resource"] == name.lower():
                             relationships.append(other_name)
 
-        post_string = f"""
-# {name} requests
-@app.post('/{name.lower()}', response_model={name}Public)
-def create_{name.lower()}(*, session: Session = Depends(get_session), {name.lower()}: {name}Create):
-    {name.lower()} = {name}.model_validate({name.lower()})
-    session.add({name.lower()})
-    session.commit()
-    session.refresh({name.lower()})
-    return {name.lower()}"""
-
+        has_relations = len(foreign_keys) > 0 or len(relationships) > 0
+        has_fk = len(foreign_keys) > 0
         pk = schema.primary_key[0]
+        name_lower = name.lower()
+        list_response_model = f"{name}PublicWithAll" if has_relations else f"{name}Public"
+        get_response_model = f"{name}PublicWithAll" if has_relations else f"{name}Public"
 
-        getall_string = f"""
-@app.get('/{name.lower()}/all', response_model=list[{f"{name}PublicWithAll" if ((len(foreign_keys) > 0) | (len(relationships) > 0)) else f"{name}Public"}])
-def read_{name.lower()}s(*, session: Session = Depends(get_session)):
-    {name.lower()}s = session.exec(select({name})).all()
-    return {name.lower()}s"""
-
-        if len(foreign_keys) > 0:
-            query_string = f"""
-@app.get('/{name.lower()}/query', response_model=list[{name}PublicWithAll])
-async def query_{name.lower()}s(*, session: AsyncSession = Depends(get_session), query=QueryBuilder({name})):
-    {name.lower()}s = session.execute(query)
-    return {name.lower()}s.scalars().all()"""
-        else:
-            query_string = ""
-
-        get_string = f"""
-@app.get('/{name.lower()}/{{{name.lower()}_{pk}}}', response_model={f"{name}PublicWithAll" if ((len(foreign_keys) > 0) | (len(relationships) > 0)) else f"{name}Public"})
-def read_{name.lower()}(*, session: Session = Depends(get_session), {name.lower()}_{pk}: str):
-    {name.lower()} = session.get({name}, {name.lower()}_{pk})
-    if not {name.lower()}:
-        raise HTTPException(status_code=404, detail='{name} not found.')
-    return {name.lower()}"""
-
-        update_string = f"""
-@app.patch('/{name.lower()}/{{{name.lower()}_{pk}}}', response_model={name}Public)
-def update_{name.lower()}(*, session: Session = Depends(get_session), {name.lower()}_{pk}: str, {name.lower()}: {name}Update):
-    db_{name.lower()} = session.get({name}, {name.lower()}_{pk})
-    if not db_{name.lower()}:
-        raise HTTPException(status_code=404, detail=f'{name} {{{name.lower()}_{pk}}} not found.')
-    {name.lower()}_data = {name.lower()}.model_dump(exclude_unset=True)
-    db_{name.lower()}.sqlmodel_update({name.lower()}_data)
-    session.add(db_{name.lower()})
-    session.commit()
-    session.refresh(db_{name.lower()})
-    return db_{name.lower()}"""
-
-        delete_string = f"""
-@app.delete('/{name.lower()}/{{{name.lower()}_{pk}}}')
-def delete_{name.lower()}(*, session: Session = Depends(get_session), {name.lower()}_{pk}: str):
-    {name.lower()} = session.get({name}, {name.lower()}_{pk})
-    if not {name.lower()}:
-        raise HTTPException(status_code=404, detail=f'{name} {{{name.lower()}_{pk}}} not found.')
-    session.delete({name.lower()})
-    session.commit()
-    return {{'ok': True}}"""
-
-        endpoint_file = f"""
-        {post_string}
-        {getall_string}
-        {get_string}
-        {query_string}
-        {update_string}
-        {delete_string}
-        """
-
-        return endpoint_file
+        template = _env.get_template("endpoint_block.py.jinja2")
+        return template.render(
+            name=name,
+            name_lower=name_lower,
+            pk=pk,
+            has_fk=has_fk,
+            has_relations=has_relations,
+            list_response_model=list_response_model,
+            get_response_model=get_response_model,
+        )
 
     def save(self, filepath: str | os.PathLike):
+        header = _env.get_template("app_header.py.jinja2").render()
         with open(filepath, "w") as file:
-            file.write("".join([self.header] + self.endpoints))
+            file.write(header + "".join(self.endpoints))

--- a/fastapifromfrictionless/database.py
+++ b/fastapifromfrictionless/database.py
@@ -1,37 +1,42 @@
 # build the database.py file for sqlmodel
 import logging
 from os import PathLike
+from pathlib import Path
+
+import jinja2
 
 logger = logging.getLogger(__name__)
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+_env = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(str(_TEMPLATES_DIR)),
+    variable_start_string="<<",
+    variable_end_string=">>",
+    block_start_string="<%",
+    block_end_string="%>",
+    comment_start_string="<#",
+    comment_end_string="#>",
+    trim_blocks=True,
+    lstrip_blocks=True,
+    keep_trailing_newline=True,
+)
 
 
 class database:
     _database_logger = logging.getLogger(__name__).getChild(__qualname__)
 
     def __init__(self, folder):
-
         self.folder = folder
         self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__).getChild(folder)
-
         self.logger.info(f"Building database from schemas in folder {folder}")
 
     def build(self, db_filepath: str | PathLike):
-        self.database = f"""
-from sqlmodel import SQLModel, create_engine
-
-sqlite_filename = '{db_filepath}'
-sqlite_url = f"sqlite:///{{sqlite_filename}}"
-
-connect_args = {{'check_same_thread': False}}
-engine = create_engine(sqlite_url, echo=True, connect_args=connect_args)
-
-def create_db_and_tables():
-    SQLModel.metadata.create_all(engine)
-"""
+        template = _env.get_template("database.py.jinja2")
+        self.database = template.render(db_filepath=str(db_filepath))
         return self
 
     def save(self, filepath: str | PathLike):
-
         self.logger.info(f"Saving database file to {filepath}")
         with open(filepath, "w") as file:
             file.write(self.database)

--- a/fastapifromfrictionless/model.py
+++ b/fastapifromfrictionless/model.py
@@ -1,14 +1,16 @@
 # fastapifromfrictionless.model
 # Tools for building SQLmodels from Frictionless Schemas
 
-## Setup logger
 import logging
-
-logger = logging.getLogger(__name__)
-
+import os
 from os import PathLike
+from pathlib import Path
+
+import jinja2
 
 from .validate import assert_schemas_valid
+
+logger = logging.getLogger(__name__)
 
 type_map = {
     "string": {
@@ -32,6 +34,21 @@ type_map = {
     "geojson": {"default": "Geometry('GEOMETRY')"},
 }
 
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+_env = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(str(_TEMPLATES_DIR)),
+    variable_start_string="<<",
+    variable_end_string=">>",
+    block_start_string="<%",
+    block_end_string="%>",
+    comment_start_string="<#",
+    comment_end_string="#>",
+    trim_blocks=True,
+    lstrip_blocks=True,
+    keep_trailing_newline=True,
+)
+
 
 class models:
     _models_logger = logging.getLogger(__name__).getChild(__qualname__)
@@ -46,44 +63,13 @@ class models:
             The location of the schema files
 
         """
-        import os
-
         self.logger = (
             logging.getLogger(__name__).getChild(self.__class__.__name__).getChild(str(folder))
         )
 
-        self.header = """
-from typing import Optional, List
-from uuid import UUID
-from sqlalchemy import DateTime
-from sqlmodel import Field, Relationship, SQLModel
-from datetime import date, datetime, timezone, time, timedelta
-from pydantic import EmailStr, AnyUrl, Json
-from geoalchemy2.types import Geometry
-
-def utcnow():
-    '''Returns the current time in UTC.'''
-    return datetime.now(timezone.utc)
-
-class TimestampMixin: # https://www.davidmuraya.com/blog/reusable-sqlmodel-mixins/
-    '''A mixin to add created_at and updated_at timestamp fields to a model.'''
-
-    created_at: datetime = Field(
-        default_factory=utcnow,
-        nullable=False,
-        sa_type=DateTime(timezone=True)
-    )
-    updated_at: datetime = Field(
-        default_factory=utcnow,
-        nullable=False,
-        sa_column_kwargs={"onupdate": utcnow},
-        sa_type=DateTime(timezone=True)
-    )
-"""
         assert_schemas_valid(folder)
         self.folder: str = str(folder)
 
-        # Read schemas from folder
         self.schemas = [x for x in os.listdir(folder) if x.endswith("schema.yaml")]
         logger.info(f"Building models for schemas from {folder}: {' .'.join(self.schemas)}")
 
@@ -97,7 +83,7 @@ class TimestampMixin: # https://www.davidmuraya.com/blog/reusable-sqlmodel-mixin
         return self
 
     def build_model(self, folder: str, filename: str) -> str:
-        """Build the individual models (base, table, create, update, public, and public with relationships) for a schema
+        """Build the individual models for a schema via Jinja2 template.
 
         parameters:
         -----------
@@ -106,31 +92,23 @@ class TimestampMixin: # https://www.davidmuraya.com/blog/reusable-sqlmodel-mixin
         filename: str
             the full filename of the schema.
         """
-
-        import os
-
         import frictionless
 
         filepath = os.path.join(folder, filename)
 
-        # Store the base name of the schema as the name of the model.
         name = filename.split(".")[0].replace("-", " ").title().replace(" ", "")
 
-        # Validate path
         if not os.path.exists(filepath):
             self.logger.error(f"{filepath} does not exist.")
 
-        # Load the schema
         try:
             schema = frictionless.Schema(filepath)
         except Exception as e:
             self.logger.error(f"{e}")
 
-        # Store the foreign keys from the schema to get references to other tables.
         foreign_keys = [x["fields"][0] for x in schema.foreign_keys]
         self.logger.info(f"Schema {name} foreign keys {foreign_keys}")
 
-        # Check other schemas to see if they reference this schema
         relationships = []
         for other_filename in self.schemas:
             if other_filename != filename:
@@ -143,149 +121,92 @@ class TimestampMixin: # https://www.davidmuraya.com/blog/reusable-sqlmodel-mixin
                             self.logger.debug(f"{name} is referenced by {other_name}")
                             relationships.append(other_name)
                         else:
-                            self.logger.debug(f"{name} not reference by {other_name}")
+                            self.logger.debug(f"{name} not referenced by {other_name}")
         if len(relationships) == 0:
             self.logger.info(f"{name} not referenced by other schemas.")
         else:
             self.logger.info(f"{name} is referenced by {relationships}")
 
-        # Check if primary key is 'id'. These will be build in SQLmodel to be auto-incrementing.
         auto_id = "id" in schema.primary_key
         if auto_id:
             self.logger.info("Primary key is 'id'. Will add to table model with autoincrement.")
 
-        # Check if schema is for a many-to-many link table
-        if (len(foreign_keys) == 2) & (len(schema.primary_key) == 2):
-            link_table = True
+        link_table = (len(foreign_keys) == 2) and (len(schema.primary_key) == 2)
+        if link_table:
             self.logger.info(f"{name} is a many-to-many link table.")
-        else:
-            link_table = False
 
-        # Build the base model
+        # Build base model field strings
         basemodel_fields: list[str] = []
-
-        # For each field in the scheme create a string for the model.
         for field_name in schema.field_names:
             field = schema.get_field(field_name)
 
-            # Skip id, will include in table model.
             if (field.name == "id") and auto_id:
                 continue
+
+            field_string = f"{field.name}: "
+            field_string += f"{type_map[field.type][field.format]}"
+
+            if "required" not in field.constraints:
+                field_string += " | None"
+                required = False
             else:
-                # Build strong from schema attributes.
-                field_string = ""
-                field_string += f"{field.name}: "
-                field_string += f"{type_map[field.type][field.format]}"
+                required = True
 
-                # Check if field is required by looking at the constraints descriptor.
-                if "required" not in field.constraints:
-                    field_string += " | None"
-                    required = False
-                else:
-                    required = True
+            if field.name in schema.primary_key:
+                field_string += " = Field(primary_key = True)"
 
-                # Check if the field is a primary key
-                if field.name in schema.primary_key:
-                    field_string += " = Field(primary_key = True)"
-
-                # Check if the field is a foreign key
-                if field.name in foreign_keys:
-                    if " = Field(primary_key = True)" in field_string:
-                        field_string = f"{field_string.rstrip(')')}, foreign_key='{field.name.replace('_', '.')}')"
-                    else:
-                        field_string += f" = Field({'default=None, ' if required else ''}foreign_key='{field.name.replace('_', '.')}')"
-
-                self.logger.info(f"{field} converted to {field_string}")
-                basemodel_fields.append(field_string)
-
-        basemodel_string = f"""class {name}Base(SQLModel):
-    {"\n    ".join(basemodel_fields)}
-"""
-        self.logger.debug(f"{basemodel_string}")
-
-        # Build table model
-        tablemodel_string = f"""class {name}({name}Base, TimestampMixin, table=True):
-"""
-        # If primary key is 'id' add to table.
-        if auto_id:
-            tablemodel_string += "    id: int | None = Field(default=None, primary_key=True)\n"
-
-        # If schema is referenced by other schemas add to table
-        if len(relationships) > 0:
-            for relationship in relationships:
-                tablemodel_string += f"    {relationship.lower()}s: list['{relationship}'] | None = Relationship(back_populates='{name.lower()}s')\n"
-
-        # If schema references other schemas add to table.
-        if len(foreign_keys) > 0:
-            for fk in foreign_keys:
-                tablemodel_string += f"    {fk.split('_')[0]}s: list['{fk.split('_')[0].capitalize()}'] | None = Relationship(back_populates='{name.lower()}s')\n"
-        if (not auto_id) & (len(relationships) == 0) & (len(foreign_keys) == 0):
-            tablemodel_string += "    pass\n"
-
-        self.logger.info(f"{tablemodel_string}")
-
-        # Build Create model
-        createmodel_string = f"""class {name}Create({name}Base):
-    pass
-"""
-        self.logger.debug(f"{createmodel_string}")
-
-        # Build update model
-        updatemodel_string = f"""class {name}Update({name}Base):\n"""
-        for field_str in basemodel_fields:
-            # Remove everything except datatype and None
-            if " = " in field_str:
-                field_str = field_str.split(" = ")[0]
-            if " | None" not in field_str:
-                updatemodel_string += f"    {field_str} | None\n"
-            else:
-                updatemodel_string += f"    {field_str}\n"
-
-        self.logger.debug(f"{updatemodel_string}")
-
-        # Build public model
-        publicmodel_string = f"""class {name}Public({name}Base):{"\n    id: int" if auto_id else ""}
-    created_at: datetime
-    updated_at: datetime
-"""
-        self.logger.debug(f"{publicmodel_string}")
-
-        # Build public with relationships model for models with foreign keys to facilitate queries
-        relationshipsmodel_string = ""
-        if (len(foreign_keys) > 0) | (len(relationships) > 0):
-            relationshipsmodel_string += f"""class {name}PublicWithAll({name}Public):\n"""
-            for fk in foreign_keys:
-                relationshipsmodel_string += f"    {fk.split('_')[0]}s: List['{fk.split('_')[0].capitalize()}Public'] | None = None\n"
-            for relationship in relationships:
-                if relationship.startswith("Link"):
-                    joined = relationship.replace("Link", "").replace(name, "").replace("-", "")
-                    relationshipsmodel_string += f"    {relationship.lower()}s: List['{relationship}PublicWith{joined}'] | None = None\n"
-                else:
-                    relationshipsmodel_string += (
-                        f"    {relationship.lower()}s: List['{relationship}Public'] | None = None\n"
+            if field.name in foreign_keys:
+                if " = Field(primary_key = True)" in field_string:
+                    field_string = (
+                        f"{field_string.rstrip(')')}, foreign_key='{field.name.replace('_', '.')}')"
                     )
+                else:
+                    field_string += f" = Field({'default=None, ' if required else ''}foreign_key='{field.name.replace('_', '.')}')"
 
-        if link_table:
-            for fk in foreign_keys:
-                relationshipsmodel_string += (
-                    f"""\nclass {name}PublicWith{fk.split("_")[0].capitalize()}({name}Public):\n"""
-                )
-                relationshipsmodel_string += f"    {fk.split('_')[0]}s: List['{fk.split('_')[0].capitalize()}Public'] | None = None\n\n"
+            self.logger.info(f"{field} converted to {field_string}")
+            basemodel_fields.append(field_string)
 
-        self.logger.debug(f"{relationshipsmodel_string}")
+        # Precompute derived template context
+        basemodel_fields_str = "\n    ".join(basemodel_fields)
 
-        return f"""
-## {name} models
-{basemodel_string}
-{tablemodel_string}
-{createmodel_string}
-{updatemodel_string}
-{publicmodel_string}
-{relationshipsmodel_string}
-    """
+        update_lines = []
+        for fs in basemodel_fields:
+            fs = fs.split(" = ")[0] if " = " in fs else fs
+            if " | None" not in fs:
+                fs += " | None"
+            update_lines.append(f"    {fs}")
+        update_fields_str = "\n".join(update_lines)
+
+        fk_models = [
+            {"field": fk, "prefix": fk.split("_")[0], "related": fk.split("_")[0].capitalize()}
+            for fk in foreign_keys
+        ]
+
+        rel_models = []
+        for rel in relationships:
+            is_link = rel.startswith("Link")
+            joined = rel.replace("Link", "").replace(name, "").replace("-", "") if is_link else ""
+            rel_models.append(
+                {"name": rel, "lower_name": rel.lower(), "is_link": is_link, "joined": joined}
+            )
+
+        template = _env.get_template("model_block.py.jinja2")
+        result = template.render(
+            name=name,
+            auto_id=auto_id,
+            link_table=link_table,
+            basemodel_fields_str=basemodel_fields_str,
+            update_fields_str=update_fields_str,
+            foreign_keys=foreign_keys,
+            relationships=relationships,
+            fk_models=fk_models,
+            rel_models=rel_models,
+        )
+        self.logger.debug(result)
+        return result
 
     def save(self, path: str | PathLike):
+        header = _env.get_template("models_header.py.jinja2").render()
         with open(path, "w") as file:
-            file_string = "".join([self.header] + self.models)
-            file.write(file_string)
+            file.write(header + "".join(self.models))
             logger.info(f"models saved to {path}")

--- a/fastapifromfrictionless/templates/app_header.py.jinja2
+++ b/fastapifromfrictionless/templates/app_header.py.jinja2
@@ -1,0 +1,26 @@
+
+# app.py
+from fastapi import Depends, FastAPI, HTTPException, Query
+import fastapi
+from fastapi_querybuilder import QueryBuilder
+from sqlalchemy import text
+from sqlmodel import Session, select
+from .database import create_db_and_tables, engine
+from .models import *
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Initiate app
+app = FastAPI()
+
+# Dependencies
+@app.on_event('startup')
+def on_startup():
+    create_db_and_tables()
+
+def get_session():
+    with Session(engine) as session:
+        yield session
+
+# @app.get('/')
+# def read_schema(*, session: Session = Depends(get_session)):
+#     return {name.lower()}s

--- a/fastapifromfrictionless/templates/database.py.jinja2
+++ b/fastapifromfrictionless/templates/database.py.jinja2
@@ -1,0 +1,11 @@
+
+from sqlmodel import SQLModel, create_engine
+
+sqlite_filename = '<< db_filepath >>'
+sqlite_url = f"sqlite:///{sqlite_filename}"
+
+connect_args = {'check_same_thread': False}
+engine = create_engine(sqlite_url, echo=True, connect_args=connect_args)
+
+def create_db_and_tables():
+    SQLModel.metadata.create_all(engine)

--- a/fastapifromfrictionless/templates/endpoint_block.py.jinja2
+++ b/fastapifromfrictionless/templates/endpoint_block.py.jinja2
@@ -1,0 +1,50 @@
+
+
+# << name >> requests
+@app.post('/<< name_lower >>', response_model=<< name >>Public)
+def create_<< name_lower >>(*, session: Session = Depends(get_session), << name_lower >>: << name >>Create):
+    << name_lower >> = << name >>.model_validate(<< name_lower >>)
+    session.add(<< name_lower >>)
+    session.commit()
+    session.refresh(<< name_lower >>)
+    return << name_lower >>
+
+@app.get('/<< name_lower >>/all', response_model=list[<< list_response_model >>])
+def read_<< name_lower >>s(*, session: Session = Depends(get_session)):
+    << name_lower >>s = session.exec(select(<< name >>)).all()
+    return << name_lower >>s
+<% if has_fk %>
+
+@app.get('/<< name_lower >>/query', response_model=list[<< name >>PublicWithAll])
+async def query_<< name_lower >>s(*, session: AsyncSession = Depends(get_session), query=QueryBuilder(<< name >>)):
+    << name_lower >>s = session.execute(query)
+    return << name_lower >>s.scalars().all()
+<% endif %>
+
+@app.get('/<< name_lower >>/{<< name_lower >>_<< pk >>}', response_model=<< get_response_model >>)
+def read_<< name_lower >>(*, session: Session = Depends(get_session), << name_lower >>_<< pk >>: str):
+    << name_lower >> = session.get(<< name >>, << name_lower >>_<< pk >>)
+    if not << name_lower >>:
+        raise HTTPException(status_code=404, detail='<< name >> not found.')
+    return << name_lower >>
+
+@app.patch('/<< name_lower >>/{<< name_lower >>_<< pk >>}', response_model=<< name >>Public)
+def update_<< name_lower >>(*, session: Session = Depends(get_session), << name_lower >>_<< pk >>: str, << name_lower >>: << name >>Update):
+    db_<< name_lower >> = session.get(<< name >>, << name_lower >>_<< pk >>)
+    if not db_<< name_lower >>:
+        raise HTTPException(status_code=404, detail=f'<< name >> {<< name_lower >>_<< pk >>} not found.')
+    << name_lower >>_data = << name_lower >>.model_dump(exclude_unset=True)
+    db_<< name_lower >>.sqlmodel_update(<< name_lower >>_data)
+    session.add(db_<< name_lower >>)
+    session.commit()
+    session.refresh(db_<< name_lower >>)
+    return db_<< name_lower >>
+
+@app.delete('/<< name_lower >>/{<< name_lower >>_<< pk >>}')
+def delete_<< name_lower >>(*, session: Session = Depends(get_session), << name_lower >>_<< pk >>: str):
+    << name_lower >> = session.get(<< name >>, << name_lower >>_<< pk >>)
+    if not << name_lower >>:
+        raise HTTPException(status_code=404, detail=f'<< name >> {<< name_lower >>_<< pk >>} not found.')
+    session.delete(<< name_lower >>)
+    session.commit()
+    return {'ok': True}

--- a/fastapifromfrictionless/templates/model_block.py.jinja2
+++ b/fastapifromfrictionless/templates/model_block.py.jinja2
@@ -1,0 +1,54 @@
+
+
+## << name >> models
+class << name >>Base(SQLModel):
+    << basemodel_fields_str >>
+
+class << name >>(<< name >>Base, TimestampMixin, table=True):
+<% if auto_id %>
+    id: int | None = Field(default=None, primary_key=True)
+<% endif %>
+<% for rel in relationships %>
+    << rel.lower() >>s: list['<< rel >>'] | None = Relationship(back_populates='<< name.lower() >>s')
+<% endfor %>
+<% for fk in fk_models %>
+    << fk.prefix >>s: list['<< fk.related >>'] | None = Relationship(back_populates='<< name.lower() >>s')
+<% endfor %>
+<% if not auto_id and not relationships and not foreign_keys %>
+    pass
+<% endif %>
+
+class << name >>Create(<< name >>Base):
+    pass
+
+class << name >>Update(<< name >>Base):
+<< update_fields_str >>
+
+class << name >>Public(<< name >>Base):
+<% if auto_id %>
+    id: int
+<% endif %>
+    created_at: datetime
+    updated_at: datetime
+<% if foreign_keys or relationships %>
+
+class << name >>PublicWithAll(<< name >>Public):
+<% for fk in fk_models %>
+    << fk.prefix >>s: List['<< fk.related >>Public'] | None = None
+<% endfor %>
+<% for rel in rel_models %>
+<% if rel.is_link %>
+    << rel.lower_name >>s: List['<< rel.name >>PublicWith<< rel.joined >>'] | None = None
+<% else %>
+    << rel.lower_name >>s: List['<< rel.name >>Public'] | None = None
+<% endif %>
+<% endfor %>
+<% endif %>
+<% if link_table %>
+<% for fk in fk_models %>
+
+class << name >>PublicWith<< fk.related >>(<< name >>Public):
+    << fk.prefix >>s: List['<< fk.related >>Public'] | None = None
+
+<% endfor %>
+<% endif %>

--- a/fastapifromfrictionless/templates/models_header.py.jinja2
+++ b/fastapifromfrictionless/templates/models_header.py.jinja2
@@ -1,0 +1,27 @@
+
+from typing import Optional, List
+from uuid import UUID
+from sqlalchemy import DateTime
+from sqlmodel import Field, Relationship, SQLModel
+from datetime import date, datetime, timezone, time, timedelta
+from pydantic import EmailStr, AnyUrl, Json
+from geoalchemy2.types import Geometry
+
+def utcnow():
+    '''Returns the current time in UTC.'''
+    return datetime.now(timezone.utc)
+
+class TimestampMixin: # https://www.davidmuraya.com/blog/reusable-sqlmodel-mixins/
+    '''A mixin to add created_at and updated_at timestamp fields to a model.'''
+
+    created_at: datetime = Field(
+        default_factory=utcnow,
+        nullable=False,
+        sa_type=DateTime(timezone=True)
+    )
+    updated_at: datetime = Field(
+        default_factory=utcnow,
+        nullable=False,
+        sa_column_kwargs={"onupdate": utcnow},
+        sa_type=DateTime(timezone=True)
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "FastAPI",
     "fastapi_querybuilder",
     "sqlalchemy",
-    "xlsxwriter"
+    "xlsxwriter",
+    "jinja2",
 ]
 
 [project.optional-dependencies]
@@ -46,6 +47,7 @@ namespaces = false
 
 [tool.setuptools.package-data]
 "*" = ["*.json"]
+fastapifromfrictionless = ["templates/*.jinja2"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #26: Jinja2 templating
+
+Replaced raw f-string generation in `model.py`, `app.py`, and `database.py` with Jinja2 templates in `fastapifromfrictionless/templates/`. Used custom delimiters (`<< >>` for variables, `<% %>` for blocks) to avoid conflicts with Python's `{}` syntax in generated code. All logic (FK detection, type mapping, relationship building) stays in Python; templates handle layout only. Added `jinja2` to runtime dependencies and `templates/*.jinja2` to package-data. Added `jinja2` to `pyproject.toml` runtime dependencies. All 44 tests pass; ruff and mypy clean.
+
+---
+
 ## 2026-05-13 — Issue #22: Type hints and mypy
 
 Fixed 19 mypy errors across the package: (1) renamed loop variable `field` to `field_name` in `model.py` to avoid shadowing between `str` and `frictionless.Field` types; (2) annotated `basemodel_fields: list[str]` explicitly; (3) cast `PathLike` to `str` in `logging.getChild()` calls in `model.py` and `app.py`; (4) stored `self.folder` as `str` in both generators; (5) replaced `filename.split(".")` with `pathlib.Path(filename).stem` in `load.py`. Added `[tool.mypy]` config to `pyproject.toml`, `mypy` to `[dev]` extras, and a mypy step to the CI workflow. Also fixed 51 ruff issues and reformatted all source files. mypy and all 44 tests clean.


### PR DESCRIPTION
## Summary

- Moves all generated Python source text out of `model.py`, `app.py`, and `database.py` into `fastapifromfrictionless/templates/` (5 `.jinja2` files)
- Uses custom Jinja2 delimiters (`<< >>` variables, `<% %>` blocks) to avoid conflicts with Python's `{}` syntax in the generated code
- All logic (FK detection, type mapping, relationship building) remains in Python; templates handle text layout only
- Adds `jinja2` to runtime dependencies; adds `templates/*.jinja2` to package-data

## Test plan

- [ ] All 44 existing tests pass (`pytest`)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy fastapifromfrictionless/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)