### PR TITLE
Add configure_logging() for structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Items are grouped by priority. Checked items are complete.
 - [x] Add CI pipeline (lint, type-check, tests on push)
 - [x] Enforce type hints throughout; run `mypy` in CI
 - [x] Replace raw string generation with a templating engine (e.g. Jinja2) for maintainability
-- [ ] Structured logging with configurable verbosity
+- [x] Structured logging with configurable verbosity
 
 ### Production Readiness
 

--- a/fastapifromfrictionless/__init__.py
+++ b/fastapifromfrictionless/__init__.py
@@ -7,5 +7,6 @@ logger = logging.getLogger(__name__)
 from .app import app
 from .database import database
 from .load import *
+from .logging_config import configure_logging
 from .model import models
 from .validate import assert_schemas_valid, validate_schemas

--- a/fastapifromfrictionless/logging_config.py
+++ b/fastapifromfrictionless/logging_config.py
@@ -1,0 +1,33 @@
+import logging
+import sys
+
+_DEFAULT_FMT = "%(asctime)s %(levelname)-8s %(name)s — %(message)s"
+_DEFAULT_DATEFMT = "%Y-%m-%dT%H:%M:%S"
+
+_pkg_logger = logging.getLogger("fastapifromfrictionless")
+
+
+def configure_logging(
+    level: str | int = "INFO",
+    fmt: str = _DEFAULT_FMT,
+    datefmt: str = _DEFAULT_DATEFMT,
+) -> None:
+    """Configure the fastapifromfrictionless package logger.
+
+    Sets the log level, clears any existing handlers, and attaches a
+    StreamHandler to stderr. Sets propagate=False so that the package's
+    log records do not bubble up to the root logger.
+    """
+    if isinstance(level, str):
+        numeric = logging.getLevelName(level.upper())
+        if not isinstance(numeric, int):
+            raise ValueError(f"Unknown log level: {level!r}")
+        level = numeric
+
+    _pkg_logger.handlers.clear()
+    _pkg_logger.setLevel(level)
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter(fmt=fmt, datefmt=datefmt))
+    _pkg_logger.addHandler(handler)
+    _pkg_logger.propagate = False

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #28: Structured logging
+
+Added `fastapifromfrictionless/logging_config.py` with `configure_logging(level, fmt, datefmt)`. Sets level on the `fastapifromfrictionless` package root logger, clears existing handlers on repeated calls, attaches `StreamHandler(sys.stderr)` with a default format `%(asctime)s %(levelname)-8s %(name)s — %(message)s`, and sets `propagate=False`. Accepts both string level names (case-insensitive) and integer levels; raises `ValueError` for unknown strings. Exported from `__init__.py`. 9 tests added; all 53 pass.
+
+---
+
 ## 2026-05-13 — Issue #26: Jinja2 templating
 
 Replaced raw f-string generation in `model.py`, `app.py`, and `database.py` with Jinja2 templates in `fastapifromfrictionless/templates/`. Used custom delimiters (`<< >>` for variables, `<% %>` for blocks) to avoid conflicts with Python's `{}` syntax in generated code. All logic (FK detection, type mapping, relationship building) stays in Python; templates handle layout only. Added `jinja2` to runtime dependencies and `templates/*.jinja2` to package-data. Added `jinja2` to `pyproject.toml` runtime dependencies. All 44 tests pass; ruff and mypy clean.

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,59 @@
+"""Unit tests for configure_logging."""
+
+import logging
+import sys
+
+import pytest
+
+from fastapifromfrictionless import configure_logging
+
+PKG = "fastapifromfrictionless"
+
+
+def test_default_level_is_info():
+    configure_logging()
+    assert logging.getLogger(PKG).level == logging.INFO
+
+
+def test_debug_level_accepted():
+    configure_logging("DEBUG")
+    assert logging.getLogger(PKG).level == logging.DEBUG
+
+
+def test_integer_level_accepted():
+    configure_logging(logging.WARNING)
+    assert logging.getLogger(PKG).level == logging.WARNING
+
+
+def test_exactly_one_handler_after_call():
+    configure_logging()
+    assert len(logging.getLogger(PKG).handlers) == 1
+
+
+def test_repeated_calls_do_not_stack_handlers():
+    configure_logging()
+    configure_logging()
+    configure_logging()
+    assert len(logging.getLogger(PKG).handlers) == 1
+
+
+def test_handler_writes_to_stderr():
+    configure_logging()
+    handler = logging.getLogger(PKG).handlers[0]
+    assert isinstance(handler, logging.StreamHandler)
+    assert handler.stream is sys.stderr
+
+
+def test_propagate_is_false():
+    configure_logging()
+    assert logging.getLogger(PKG).propagate is False
+
+
+def test_unknown_level_raises():
+    with pytest.raises(ValueError):
+        configure_logging("NOTLEVEL")
+
+
+def test_case_insensitive_level():
+    configure_logging("debug")
+    assert logging.getLogger(PKG).level == logging.DEBUG


### PR DESCRIPTION
## Summary

- Adds `fastapifromfrictionless/logging_config.py` with `configure_logging(level, fmt, datefmt)`
- Clears existing handlers on repeated calls (no handler accumulation)
- Attaches `StreamHandler` to stderr with a structured default format
- Sets `propagate=False` so package logs don't bubble to the root logger
- Accepts string levels (case-insensitive) or integers; raises `ValueError` for unknown strings
- Exported from `__init__.py`

## Test plan

- [ ] 9 new tests in `tests/test_logging_config.py` all pass
- [ ] All 53 tests pass (`pytest`)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy fastapifromfrictionless/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)