### PR TITLE
Add consistent JSON error handlers to generated app.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Items are grouped by priority. Checked items are complete.
 - [ ] CORS and security headers in generated `app.py`
 - [ ] API key / token authentication ([FastAPI security](https://fastapi.tiangolo.com/tutorial/security/first-steps/))
 - [ ] Pagination on list endpoints
-- [ ] Proper HTTP error responses with consistent JSON error bodies
+- [x] Proper HTTP error responses with consistent JSON error bodies
 
 ### Developer Experience
 

--- a/fastapifromfrictionless/templates/app_header.py.jinja2
+++ b/fastapifromfrictionless/templates/app_header.py.jinja2
@@ -1,6 +1,8 @@
 
 # app.py
 from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 import fastapi
 from fastapi_querybuilder import QueryBuilder
 from sqlalchemy import text
@@ -11,6 +13,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 # Initiate app
 app = FastAPI()
+
+# Exception handlers
+@app.exception_handler(HTTPException)
+def http_exception_handler(request, exc):
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"error": exc.detail, "status_code": exc.status_code},
+    )
+
+@app.exception_handler(RequestValidationError)
+def validation_exception_handler(request, exc):
+    return JSONResponse(
+        status_code=422,
+        content={"error": "Validation error", "detail": exc.errors()},
+    )
 
 # Dependencies
 @app.on_event('startup')

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #30: HTTP error responses
+
+Added custom `HTTPException` and `RequestValidationError` handlers to the generated `app_header.py.jinja2` template. Both return consistent JSON bodies: `{"error": ..., "status_code": ...}` for HTTP errors and `{"error": "Validation error", "detail": [...]}` for validation failures. 2 tests added; all 55 pass.
+
+---
+
 ## 2026-05-13 — Issue #28: Structured logging
 
 Added `fastapifromfrictionless/logging_config.py` with `configure_logging(level, fmt, datefmt)`. Sets level on the `fastapifromfrictionless` package root logger, clears existing handlers on repeated calls, attaches `StreamHandler(sys.stderr)` with a default format `%(asctime)s %(levelname)-8s %(name)s — %(message)s`, and sets `propagate=False`. Accepts both string level names (case-insensitive) and integer levels; raises `ValueError` for unknown strings. Exported from `__init__.py`. 9 tests added; all 53 pass.

--- a/tests/test_app_generator.py
+++ b/tests/test_app_generator.py
@@ -153,3 +153,24 @@ def test_save_writes_file(simple_folder, tmp_path):
     content = out.read_text()
     assert "FastAPI" in content
     assert "create_location" in content
+
+
+# ---------------------------------------------------------------------------
+# HTTP error response handlers
+# ---------------------------------------------------------------------------
+
+
+def test_http_exception_handler_in_saved_file(simple_folder, tmp_path):
+    out = tmp_path / "app.py"
+    app(str(simple_folder)).build().save(out)
+    content = out.read_text()
+    assert "exception_handler(HTTPException)" in content
+    assert "JSONResponse" in content
+
+
+def test_validation_exception_handler_in_saved_file(simple_folder, tmp_path):
+    out = tmp_path / "app.py"
+    app(str(simple_folder)).build().save(out)
+    content = out.read_text()
+    assert "exception_handler(RequestValidationError)" in content
+    assert "exc.errors()" in content


### PR DESCRIPTION
## Summary

- Adds `@app.exception_handler(HTTPException)` to generated `app.py`, returning `{"error": ..., "status_code": ...}` instead of FastAPI's default `{"detail": ...}`
- Adds `@app.exception_handler(RequestValidationError)` returning `{"error": "Validation error", "detail": [...]}` for 422 responses
- Adds imports for `RequestValidationError` and `JSONResponse` to the generated header

## Test plan

- [ ] 2 new tests verify exception handlers appear in saved `app.py`
- [ ] All 55 tests pass (`pytest`)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy fastapifromfrictionless/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)