### PR TITLE
Add offset/limit pagination to generated list endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Items are grouped by priority. Checked items are complete.
 - [ ] Configuration management — accept settings via environment variables or a config file (database URL, allowed origins, etc.)
 - [ ] CORS and security headers in generated `app.py`
 - [ ] API key / token authentication ([FastAPI security](https://fastapi.tiangolo.com/tutorial/security/first-steps/))
-- [ ] Pagination on list endpoints
+- [x] Pagination on list endpoints
 - [x] Proper HTTP error responses with consistent JSON error bodies
 
 ### Developer Experience

--- a/fastapifromfrictionless/templates/endpoint_block.py.jinja2
+++ b/fastapifromfrictionless/templates/endpoint_block.py.jinja2
@@ -10,8 +10,8 @@ def create_<< name_lower >>(*, session: Session = Depends(get_session), << name_
     return << name_lower >>
 
 @app.get('/<< name_lower >>/all', response_model=list[<< list_response_model >>])
-def read_<< name_lower >>s(*, session: Session = Depends(get_session)):
-    << name_lower >>s = session.exec(select(<< name >>)).all()
+def read_<< name_lower >>s(*, session: Session = Depends(get_session), offset: int = 0, limit: int = Query(default=100, le=1000)):
+    << name_lower >>s = session.exec(select(<< name >>).offset(offset).limit(limit)).all()
     return << name_lower >>s
 <% if has_fk %>
 

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #32: Pagination
+
+Added `offset: int = 0` and `limit: int = Query(default=100, le=1000)` parameters to all generated `GET /all` endpoints. Uses SQLModel's `.offset().limit()` chaining on the select statement. 3 tests added; all 58 pass.
+
+---
+
 ## 2026-05-13 — Issue #30: HTTP error responses
 
 Added custom `HTTPException` and `RequestValidationError` handlers to the generated `app_header.py.jinja2` template. Both return consistent JSON bodies: `{"error": ..., "status_code": ...}` for HTTP errors and `{"error": "Validation error", "detail": [...]}` for validation failures. 2 tests added; all 55 pass.

--- a/tests/test_app_generator.py
+++ b/tests/test_app_generator.py
@@ -156,6 +156,26 @@ def test_save_writes_file(simple_folder, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+
+def test_get_all_has_offset_param(simple_folder):
+    out = _output(simple_folder)
+    assert "offset: int = 0" in out
+
+
+def test_get_all_has_limit_param(simple_folder):
+    out = _output(simple_folder)
+    assert "limit: int = Query" in out
+
+
+def test_get_all_uses_offset_limit_in_query(simple_folder):
+    out = _output(simple_folder)
+    assert ".offset(offset).limit(limit)" in out
+
+
+# ---------------------------------------------------------------------------
 # HTTP error response handlers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `GET /all` endpoints now accept `offset` (default 0) and `limit` (default 100, max 1000) query parameters
- Uses SQLModel's `.offset().limit()` chaining on the select statement
- `Query(default=100, le=1000)` enforces the maximum to prevent runaway queries

## Test plan

- [ ] 3 new tests check offset, limit params, and query usage in generated output
- [ ] All 58 tests pass (`pytest`)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy fastapifromfrictionless/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)