### PR TITLE
Add CORS middleware and security headers to generated app.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Items are grouped by priority. Checked items are complete.
 - [ ] Async database support (replace sync SQLModel sessions with async SQLAlchemy)
 - [ ] Database migrations via [Alembic](https://alembic.sqlalchemy.org/) instead of `create_all`
 - [ ] Configuration management — accept settings via environment variables or a config file (database URL, allowed origins, etc.)
-- [ ] CORS and security headers in generated `app.py`
+- [x] CORS and security headers in generated `app.py`
 - [ ] API key / token authentication ([FastAPI security](https://fastapi.tiangolo.com/tutorial/security/first-steps/))
 - [x] Pagination on list endpoints
 - [x] Proper HTTP error responses with consistent JSON error bodies

--- a/fastapifromfrictionless/templates/app_header.py.jinja2
+++ b/fastapifromfrictionless/templates/app_header.py.jinja2
@@ -1,18 +1,43 @@
 
 # app.py
+import os
 from fastapi import Depends, FastAPI, HTTPException, Query
 from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 import fastapi
 from fastapi_querybuilder import QueryBuilder
 from sqlalchemy import text
 from sqlmodel import Session, select
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
 from .database import create_db_and_tables, engine
 from .models import *
 from sqlalchemy.ext.asyncio import AsyncSession
 
 # Initiate app
 app = FastAPI()
+
+# CORS — restrict origins via ALLOWED_ORIGINS env var (comma-separated), default open for dev
+_origins = os.getenv("ALLOWED_ORIGINS", "*").split(",")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Security headers
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+        return response
+
+app.add_middleware(SecurityHeadersMiddleware)
 
 # Exception handlers
 @app.exception_handler(HTTPException)

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #34: CORS and security headers
+
+Added `CORSMiddleware` (origins from `ALLOWED_ORIGINS` env var, comma-separated, default `*` for development) and `SecurityHeadersMiddleware` (sets `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Strict-Transport-Security`) to the generated `app_header.py.jinja2` template. 2 tests added; all 60 pass.
+
+---
+
 ## 2026-05-13 — Issue #32: Pagination
 
 Added `offset: int = 0` and `limit: int = Query(default=100, le=1000)` parameters to all generated `GET /all` endpoints. Uses SQLModel's `.offset().limit()` chaining on the select statement. 3 tests added; all 58 pass.

--- a/tests/test_app_generator.py
+++ b/tests/test_app_generator.py
@@ -176,6 +176,28 @@ def test_get_all_uses_offset_limit_in_query(simple_folder):
 
 
 # ---------------------------------------------------------------------------
+# CORS and security headers
+# ---------------------------------------------------------------------------
+
+
+def test_cors_middleware_in_saved_file(simple_folder, tmp_path):
+    out = tmp_path / "app.py"
+    app(str(simple_folder)).build().save(out)
+    content = out.read_text()
+    assert "CORSMiddleware" in content
+    assert "ALLOWED_ORIGINS" in content
+
+
+def test_security_headers_middleware_in_saved_file(simple_folder, tmp_path):
+    out = tmp_path / "app.py"
+    app(str(simple_folder)).build().save(out)
+    content = out.read_text()
+    assert "SecurityHeadersMiddleware" in content
+    assert "X-Content-Type-Options" in content
+    assert "X-Frame-Options" in content
+
+
+# ---------------------------------------------------------------------------
 # HTTP error response handlers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `CORSMiddleware` with origins from `ALLOWED_ORIGINS` env var (comma-separated, default `*` for dev)
- `SecurityHeadersMiddleware` (Starlette `BaseHTTPMiddleware`) adds `X-Content-Type-Options`, `X-Frame-Options`, and `Strict-Transport-Security` to every response
- Both middlewares added before the exception handlers in the generated header

## Test plan

- [ ] 2 new tests verify CORS and security middleware appear in saved `app.py`
- [ ] All 60 tests pass (`pytest`)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy fastapifromfrictionless/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)