### PR TITLE
Add CLI: fastapifromfrictionless generate <schema-folder>

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Items are grouped by priority. Checked items are complete.
 
 ### Developer Experience
 
-- [ ] CLI entry point (`fastapifromfrictionless generate <schema-folder>`) so users do not need to write Python
+- [x] CLI entry point (`fastapifromfrictionless generate <schema-folder>`) so users do not need to write Python
 - [ ] Dry-run / preview mode that prints generated code without writing files
 - [ ] Configurable output — opt in/out of specific endpoint types, choose database backend
 - [ ] Package versioning and automated releases (GitHub Actions → PyPI)

--- a/fastapifromfrictionless/cli.py
+++ b/fastapifromfrictionless/cli.py
@@ -1,0 +1,53 @@
+"""Command-line interface for fastapifromfrictionless."""
+
+import argparse
+import pathlib
+
+
+def _generate(args):
+    from .app import app
+    from .database import database
+    from .model import models
+
+    out = pathlib.Path(args.output)
+    out.mkdir(parents=True, exist_ok=True)
+
+    models(args.schema_folder).build().save(out / "models.py")
+    app(args.schema_folder).build().save(out / "app.py")
+    database(args.schema_folder).build(args.db_filename).save(out / "database.py")
+    (out / "__init__.py").touch()
+
+    print(f"Generated app.py, models.py, database.py in {out}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="fastapifromfrictionless",
+        description="Generate a FastAPI + SQLModel app from Frictionless schema files.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    gen = subparsers.add_parser(
+        "generate",
+        help="Generate app.py, models.py, and database.py from *.schema.yaml files.",
+    )
+    gen.add_argument("schema_folder", help="Folder containing *.schema.yaml files.")
+    gen.add_argument(
+        "--output",
+        default=".",
+        help="Output directory for generated files (default: current directory).",
+    )
+    gen.add_argument(
+        "--db",
+        dest="db_filename",
+        default="database.db",
+        help="SQLite database filename (default: database.db).",
+    )
+    gen.set_defaults(func=_generate)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dev = [
     "mypy",
 ]
 
+[project.scripts]
+fastapifromfrictionless = "fastapifromfrictionless.cli:main"
+
 [build-system]
 requires = ["setuptools>=61.0", "setuptools-scm"]
 build-backend = "setuptools.build_meta"

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #38: CLI entry point
+
+Added `fastapifromfrictionless/cli.py` with a `generate` subcommand. Accepts `schema_folder` positional arg, `--output` (default `.`), and `--db` (default `database.db`). Calls the three generators directly and writes files to the output directory. Wired via `[project.scripts]` in `pyproject.toml` so `pip install -e .` makes `fastapifromfrictionless generate <schema-folder>` available. 6 tests added; all 67 pass.
+
+---
+
 ## 2026-05-13 — Issue #36: Configuration management
 
 Generated `database.py` now reads `DATABASE_URL` from the environment, falling back to the default SQLite file. `connect_args` is set conditionally (`{"check_same_thread": False}` for SQLite, `{}` otherwise) to enable PostgreSQL or other backends in production. `ALLOWED_ORIGINS` was already in `app.py`. 1 test added; all 61 pass.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,68 @@
+"""Unit tests for the CLI entry point."""
+
+import textwrap
+
+import pytest
+
+from fastapifromfrictionless.cli import main
+
+
+def write_schema(tmp_path, name, content):
+    (tmp_path / f"{name}.schema.yaml").write_text(textwrap.dedent(content))
+
+
+@pytest.fixture()
+def schema_folder(tmp_path):
+    src = tmp_path / "schemas"
+    src.mkdir()
+    write_schema(
+        src,
+        "item",
+        """\
+        fields:
+          - name: id
+            type: integer
+          - name: label
+            type: string
+        primaryKey:
+          - id
+        """,
+    )
+    return src
+
+
+def test_generate_creates_models_py(schema_folder, tmp_path):
+    out = tmp_path / "out"
+    main(["generate", str(schema_folder), "--output", str(out)])
+    assert (out / "models.py").exists()
+
+
+def test_generate_creates_app_py(schema_folder, tmp_path):
+    out = tmp_path / "out"
+    main(["generate", str(schema_folder), "--output", str(out)])
+    assert (out / "app.py").exists()
+
+
+def test_generate_creates_database_py(schema_folder, tmp_path):
+    out = tmp_path / "out"
+    main(["generate", str(schema_folder), "--output", str(out)])
+    assert (out / "database.py").exists()
+
+
+def test_generate_custom_db_filename(schema_folder, tmp_path):
+    out = tmp_path / "out"
+    main(["generate", str(schema_folder), "--output", str(out), "--db", "myapp.db"])
+    content = (out / "database.py").read_text()
+    assert "myapp.db" in content
+
+
+def test_generate_default_db_filename(schema_folder, tmp_path):
+    out = tmp_path / "out"
+    main(["generate", str(schema_folder), "--output", str(out)])
+    content = (out / "database.py").read_text()
+    assert "database.db" in content
+
+
+def test_no_command_exits():
+    with pytest.raises(SystemExit):
+        main([])


### PR DESCRIPTION
## Summary

- Adds `fastapifromfrictionless/cli.py` with a `generate` subcommand (argparse, no new dependency)
- Accepts `schema_folder` positional, `--output DIR` (default `.`), `--db FILENAME` (default `database.db`)
- Writes `app.py`, `models.py`, `database.py`, `__init__.py` to the output directory
- Wired via `[project.scripts]` in `pyproject.toml`: `fastapifromfrictionless generate path/to/schemas`

## Test plan

- [ ] 6 tests in `tests/test_cli.py` verify file creation, custom db name, default db name, and bad usage
- [ ] All 67 tests pass (`pytest`)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy fastapifromfrictionless/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)