### PR TITLE
Add API key authentication to generated app.py

### DIFF
--- a/fastapifromfrictionless/templates/app_header.py.jinja2
+++ b/fastapifromfrictionless/templates/app_header.py.jinja2
@@ -1,10 +1,11 @@
 
 # app.py
 import os
-from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, HTTPException, Query, Security
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from fastapi.security.api_key import APIKeyHeader
 import fastapi
 from fastapi_querybuilder import QueryBuilder
 from sqlalchemy import text
@@ -15,8 +16,16 @@ from .database import create_db_and_tables, engine
 from .models import *
 from sqlalchemy.ext.asyncio import AsyncSession
 
+# API key auth — set API_KEY env var to enable; leave unset to disable (dev mode)
+_API_KEY = os.getenv("API_KEY", "")
+_api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+async def verify_api_key(api_key: str = Security(_api_key_header)):
+    if _API_KEY and api_key != _API_KEY:
+        raise HTTPException(status_code=403, detail="Invalid or missing API key")
+
 # Initiate app
-app = FastAPI()
+app = FastAPI(dependencies=[Depends(verify_api_key)])
 
 # CORS — restrict origins via ALLOWED_ORIGINS env var (comma-separated), default open for dev
 _origins = os.getenv("ALLOWED_ORIGINS", "*").split(",")

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #40: API key authentication
+
+Added `X-API-Key` header authentication to the generated `app_header.py.jinja2` template using FastAPI's `APIKeyHeader` and `Security`. If `API_KEY` env var is set, all requests must include a matching header (returns 403 otherwise). If unset, auth is disabled (dev-friendly default). Applied globally via `FastAPI(dependencies=[Depends(verify_api_key)])`. 2 tests added; all 69 pass.
+
+---
+
 ## 2026-05-13 — Issue #38: CLI entry point
 
 Added `fastapifromfrictionless/cli.py` with a `generate` subcommand. Accepts `schema_folder` positional arg, `--output` (default `.`), and `--db` (default `database.db`). Calls the three generators directly and writes files to the output directory. Wired via `[project.scripts]` in `pyproject.toml` so `pip install -e .` makes `fastapifromfrictionless generate <schema-folder>` available. 6 tests added; all 67 pass.

--- a/tests/test_app_generator.py
+++ b/tests/test_app_generator.py
@@ -176,6 +176,27 @@ def test_get_all_uses_offset_limit_in_query(simple_folder):
 
 
 # ---------------------------------------------------------------------------
+# API key authentication
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_env_var_in_saved_file(simple_folder, tmp_path):
+    out = tmp_path / "app.py"
+    app(str(simple_folder)).build().save(out)
+    content = out.read_text()
+    assert "API_KEY" in content
+    assert "verify_api_key" in content
+
+
+def test_api_key_header_in_saved_file(simple_folder, tmp_path):
+    out = tmp_path / "app.py"
+    app(str(simple_folder)).build().save(out)
+    content = out.read_text()
+    assert "APIKeyHeader" in content
+    assert "X-API-Key" in content
+
+
+# ---------------------------------------------------------------------------
 # CORS and security headers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds optional `X-API-Key` header authentication using FastAPI's `APIKeyHeader` + `Security`
- If `API_KEY` env var is set, all endpoints require a matching header (403 on failure)
- If `API_KEY` is unset (default), auth is disabled — dev-friendly out of the box
- Applied globally via `FastAPI(dependencies=[Depends(verify_api_key)])` — no per-endpoint changes needed

## Test plan

- [ ] 2 new tests verify `API_KEY`, `verify_api_key`, `APIKeyHeader`, `X-API-Key` appear in saved `app.py`
- [ ] All 69 tests pass (`pytest`)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy fastapifromfrictionless/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)