### PR TITLE
Add --dry-run flag to CLI generate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Items are grouped by priority. Checked items are complete.
 ### Developer Experience
 
 - [x] CLI entry point (`fastapifromfrictionless generate <schema-folder>`) so users do not need to write Python
-- [ ] Dry-run / preview mode that prints generated code without writing files
+- [x] Dry-run / preview mode that prints generated code without writing files
 - [ ] Configurable output — opt in/out of specific endpoint types, choose database backend
 - [ ] Package versioning and automated releases (GitHub Actions → PyPI)
 - [ ] Expand documentation and examples in `doc/`

--- a/fastapifromfrictionless/cli.py
+++ b/fastapifromfrictionless/cli.py
@@ -9,15 +9,44 @@ def _generate(args):
     from .database import database
     from .model import models
 
+    models_gen = models(args.schema_folder).build()
+    app_gen = app(args.schema_folder).build()
+    db_gen = database(args.schema_folder).build(args.db_filename)
+
+    if args.dry_run:
+        _print_preview("models.py", models_gen)
+        _print_preview("app.py", app_gen)
+        _print_preview("database.py", db_gen)
+        return
+
     out = pathlib.Path(args.output)
     out.mkdir(parents=True, exist_ok=True)
 
-    models(args.schema_folder).build().save(out / "models.py")
-    app(args.schema_folder).build().save(out / "app.py")
-    database(args.schema_folder).build(args.db_filename).save(out / "database.py")
+    models_gen.save(out / "models.py")
+    app_gen.save(out / "app.py")
+    db_gen.save(out / "database.py")
     (out / "__init__.py").touch()
 
     print(f"Generated app.py, models.py, database.py in {out}")
+
+
+def _print_preview(filename, generator):
+    print(f"\n{'=' * 60}")
+    print(f"# {filename}")
+    print(f"{'=' * 60}")
+    if hasattr(generator, "models"):
+        # models generator stores header separately
+        from .model import _env
+
+        header = _env.get_template("models_header.py.jinja2").render()
+        print(header + "".join(generator.models))
+    elif hasattr(generator, "endpoints"):
+        from .app import _env
+
+        header = _env.get_template("app_header.py.jinja2").render()
+        print(header + "".join(generator.endpoints))
+    else:
+        print(generator.database)
 
 
 def main(argv=None):
@@ -42,6 +71,12 @@ def main(argv=None):
         dest="db_filename",
         default="database.db",
         help="SQLite database filename (default: database.db).",
+    )
+    gen.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Print generated file contents to stdout without writing files.",
     )
     gen.set_defaults(func=_generate)
 

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #42: Dry-run / preview mode
+
+Added `--dry-run` flag to the CLI `generate` subcommand. When set, generated file contents are printed to stdout (with `===` separators per file) instead of written to disk. Reuses the same Jinja2 environment and generator objects, just routes output to print instead of file.write. 4 tests added; all 73 pass.
+
+---
+
 ## 2026-05-13 — Issue #40: API key authentication
 
 Added `X-API-Key` header authentication to the generated `app_header.py.jinja2` template using FastAPI's `APIKeyHeader` and `Security`. If `API_KEY` env var is set, all requests must include a matching header (returns 403 otherwise). If unset, auth is disabled (dev-friendly default). Applied globally via `FastAPI(dependencies=[Depends(verify_api_key)])`. 2 tests added; all 69 pass.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,3 +66,35 @@ def test_generate_default_db_filename(schema_folder, tmp_path):
 def test_no_command_exits():
     with pytest.raises(SystemExit):
         main([])
+
+
+def test_dry_run_does_not_write_files(schema_folder, tmp_path, capsys):
+    out = tmp_path / "out"
+    main(["generate", str(schema_folder), "--output", str(out), "--dry-run"])
+    assert not (out / "models.py").exists()
+    assert not (out / "app.py").exists()
+    assert not (out / "database.py").exists()
+
+
+def test_dry_run_prints_models(schema_folder, tmp_path, capsys):
+    out = tmp_path / "out"
+    main(["generate", str(schema_folder), "--output", str(out), "--dry-run"])
+    captured = capsys.readouterr()
+    assert "models.py" in captured.out
+    assert "SQLModel" in captured.out
+
+
+def test_dry_run_prints_app(schema_folder, tmp_path, capsys):
+    out = tmp_path / "out"
+    main(["generate", str(schema_folder), "--output", str(out), "--dry-run"])
+    captured = capsys.readouterr()
+    assert "app.py" in captured.out
+    assert "FastAPI" in captured.out
+
+
+def test_dry_run_prints_database(schema_folder, tmp_path, capsys):
+    out = tmp_path / "out"
+    main(["generate", str(schema_folder), "--output", str(out), "--dry-run"])
+    captured = capsys.readouterr()
+    assert "database.py" in captured.out
+    assert "create_engine" in captured.out


### PR DESCRIPTION
## Summary

- Adds `--dry-run` flag to `fastapifromfrictionless generate`
- When set, prints generated file contents to stdout (with `=====` separators) instead of writing to disk
- Uses the same generator objects and Jinja2 environment; no duplicate logic

## Test plan

- [ ] `test_dry_run_does_not_write_files` — files absent after dry-run
- [ ] `test_dry_run_prints_models/app/database` — stdout contains expected content
- [ ] All 73 tests pass (`pytest`)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy fastapifromfrictionless/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)