### PR TITLE
Add GET /excel/export and POST /excel/import endpoints to generated app

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ Items are grouped by priority. Checked items are complete.
 - [ ] Auto-generated front-end form from schema fields
 - [ ] DrawIO ERD → Frictionless schema converter
 - [ ] Default query routes for common patterns derived from schema metadata
-- [ ] GET/POST file endpoints for uploading and downloading the Excel workbook directly via the API
+- [x] GET/POST file endpoints for uploading and downloading the Excel workbook directly via the API

--- a/fastapifromfrictionless/templates/app_header.py.jinja2
+++ b/fastapifromfrictionless/templates/app_header.py.jinja2
@@ -1,10 +1,12 @@
 
 # app.py
 import os
-from fastapi import Depends, FastAPI, HTTPException, Query, Security
+import tempfile
+from pathlib import Path
+from fastapi import Depends, FastAPI, File, HTTPException, Query, Security, UploadFile
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.security.api_key import APIKeyHeader
 import fastapi
 from fastapi_querybuilder import QueryBuilder
@@ -23,6 +25,12 @@ _api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 async def verify_api_key(api_key: str = Security(_api_key_header)):
     if _API_KEY and api_key != _API_KEY:
         raise HTTPException(status_code=403, detail="Invalid or missing API key")
+
+# Excel file endpoints config
+# Set SCHEMA_FOLDER to the directory containing *.schema.yaml files.
+# Set API_URL to the base URL of this running app (used by dump_to_excel).
+SCHEMA_FOLDER = os.getenv("SCHEMA_FOLDER", ".")
+API_URL = os.getenv("API_URL", "http://localhost:8000")
 
 # Initiate app
 app = FastAPI(dependencies=[Depends(verify_api_key)])
@@ -71,6 +79,31 @@ def on_startup():
 def get_session():
     with Session(engine) as session:
         yield session
+
+# Excel file endpoints
+@app.get('/excel/export', response_class=FileResponse)
+def export_excel():
+    from fastapifromfrictionless.load import dump_to_excel
+    tmp = tempfile.mktemp(suffix='.xlsx')
+    dump_to_excel(api_url=API_URL, schema_folder=SCHEMA_FOLDER, output_filepath=tmp)
+    return FileResponse(
+        tmp,
+        media_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        filename='export.xlsx',
+    )
+
+@app.post('/excel/import')
+async def import_excel(file: UploadFile = File(...)):
+    from fastapifromfrictionless.load import create_package, update_api_from_package
+    content = await file.read()
+    with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+        tmp.write(content)
+        excel_path = tmp.name
+    excel_stem = Path(excel_path).stem
+    create_package(folder=SCHEMA_FOLDER, filename=excel_path)
+    package_file = str(Path(SCHEMA_FOLDER) / f'{excel_stem}.package.yaml')
+    update_api_from_package(api_url=API_URL, package_file=package_file)
+    return {'status': 'imported', 'filename': file.filename}
 
 # @app.get('/')
 # def read_schema(*, session: Session = Depends(get_session)):

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-13 — Issue #48: GET/POST Excel file endpoints
+
+Added `GET /excel/export` and `POST /excel/import` routes to the generated `app_header.py.jinja2`. Export calls `dump_to_excel()` using `API_URL` and `SCHEMA_FOLDER` env vars and returns an xlsx `FileResponse`. Import accepts an `UploadFile`, saves to a temp file, runs `create_package` + `update_api_from_package` to sync rows into the database. Added `File`, `UploadFile`, `FileResponse`, `tempfile`, and `Path` imports. 3 tests added; all 79 pass.
+
+---
+
 ## 2026-05-13 — Issue #46: Package versioning and automated releases
 
 Updated `.github/workflows/python-publish.yml`: now uses `ubuntu-latest`, `fetch-depth: 0` (so setuptools-scm can read git tags), Python 3.12 consistent with CI, and correct PyPI URL (`fastapifromfrictionless`). Added `[tool.setuptools_scm]` section to `pyproject.toml` documenting the path to full scm-based versioning. Release is triggered by creating a GitHub Release (publishing a `v*` tag).

--- a/tests/test_app_generator.py
+++ b/tests/test_app_generator.py
@@ -176,6 +176,36 @@ def test_get_all_uses_offset_limit_in_query(simple_folder):
 
 
 # ---------------------------------------------------------------------------
+# Excel file endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_excel_export_endpoint_in_saved_file(simple_folder, tmp_path):
+    out = tmp_path / "app.py"
+    app(str(simple_folder)).build().save(out)
+    content = out.read_text()
+    assert "@app.get('/excel/export'" in content
+    assert "dump_to_excel" in content
+
+
+def test_excel_import_endpoint_in_saved_file(simple_folder, tmp_path):
+    out = tmp_path / "app.py"
+    app(str(simple_folder)).build().save(out)
+    content = out.read_text()
+    assert "@app.post('/excel/import')" in content
+    assert "UploadFile" in content
+    assert "update_api_from_package" in content
+
+
+def test_schema_folder_and_api_url_config_in_saved_file(simple_folder, tmp_path):
+    out = tmp_path / "app.py"
+    app(str(simple_folder)).build().save(out)
+    content = out.read_text()
+    assert "SCHEMA_FOLDER" in content
+    assert "API_URL" in content
+
+
+# ---------------------------------------------------------------------------
 # API key authentication
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `GET /excel/export` — calls `dump_to_excel()` with `API_URL` and `SCHEMA_FOLDER` env vars; returns the workbook as an xlsx `FileResponse`
- `POST /excel/import` — accepts an xlsx `UploadFile`, saves to temp, runs `create_package` + `update_api_from_package` to sync rows into the database
- Both endpoints require `SCHEMA_FOLDER` (path to `*.schema.yaml` files) and `API_URL` (base URL of this app) env vars to be set

## Test plan

- [ ] 3 new tests verify routes and key imports appear in saved `app.py`
- [ ] All 79 tests pass (`pytest`)
- [ ] `ruff check` and `ruff format --check` pass
- [ ] `mypy fastapifromfrictionless/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)