### PR TITLE
Add podman/ deployment folder (PostGIS + FastAPI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,19 @@ Options:
 
 See `doc/` for a worked example with real schemas and generated output.
 
+## Deployment
+
+A ready-to-use Podman deployment lives in `podman/`. It spins up a PostGIS database and the generated FastAPI app as two containers — no manual setup beyond dropping schemas and filling in a `.env` file:
+
+```bash
+cd podman/
+cp .env.example .env          # fill in passwords
+# add *.schema.yaml files to schemas/
+podman-compose up -d
+```
+
+See [`podman/README.md`](podman/README.md) for full instructions.
+
 ## Roadmap
 
 Items are grouped by priority. Checked items are complete.
@@ -165,6 +178,7 @@ Items are grouped by priority. Checked items are complete.
 ### Optional / Future
 
 - [x] Support for PostgreSQL and other SQLAlchemy-compatible backends
+- [x] Podman/container deployment (compose.yaml + Dockerfile + PostGIS)
 - [ ] Auto-generated front-end form from schema fields
 - [ ] DrawIO ERD → Frictionless schema converter
 - [x] Default query routes for common patterns derived from schema metadata

--- a/podman/.env.example
+++ b/podman/.env.example
@@ -1,0 +1,11 @@
+# .env.example — copy to .env and fill in values before running podman-compose
+
+# PostgreSQL credentials
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=CHANGE_ME_STRONG_PASSWORD
+POSTGRES_DB=mydb
+
+# API configuration
+API_KEY=                           # Leave empty to disable API key authentication
+ALLOWED_ORIGINS=*                  # Comma-separated CORS origins; use * for development
+API_URL=http://localhost:8000      # Public base URL of this API (used by Excel export)

--- a/podman/.gitignore
+++ b/podman/.gitignore
@@ -1,0 +1,2 @@
+.env
+postgres/

--- a/podman/Dockerfile
+++ b/podman/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir \
+    fastapifromfrictionless \
+    "uvicorn[standard]" \
+    psycopg2-binary
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8000
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/podman/README.md
+++ b/podman/README.md
@@ -1,0 +1,147 @@
+# Podman Deployment
+
+Deploy a generated FastAPI application alongside a PostGIS database using Podman Compose.
+
+## Overview
+
+This folder contains everything needed to run `fastapifromfrictionless` in a containerized environment:
+
+| File | Purpose |
+|------|---------|
+| `compose.yaml` | Defines the `postgres` (PostGIS) and `api` (FastAPI) services |
+| `Dockerfile` | Builds the API image; installs `fastapifromfrictionless` and uvicorn |
+| `entrypoint.sh` | Startup script: generates app from schemas, then launches uvicorn |
+| `.env.example` | Template for required environment variables |
+| `schemas/` | Place your `*.schema.yaml` files here |
+
+## Prerequisites
+
+Install Podman and podman-compose:
+
+```bash
+# Linux
+sudo apt -y install podman podman-compose
+
+# Windows: see https://github.com/containers/podman/blob/main/docs/tutorials/podman-for-windows.md
+```
+
+## Setup
+
+### 1. Create a deployment folder
+
+Copy the contents of this folder to a new directory on your machine:
+
+```
+my-deployment/
+  compose.yaml
+  Dockerfile
+  entrypoint.sh
+  .env.example
+  schemas/          # your *.schema.yaml files go here
+```
+
+### 2. Add your schemas
+
+Copy your `*.schema.yaml` files into the `schemas/` folder. See `doc/data/` in the main repo for examples.
+
+### 3. Configure environment variables
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` with real values:
+
+```
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=a_strong_random_password
+POSTGRES_DB=mydb
+
+API_KEY=another_strong_random_password   # or leave empty to disable auth
+ALLOWED_ORIGINS=*
+API_URL=http://localhost:8000
+```
+
+> **Security**: `.env` is listed in `.gitignore`. Never commit it.
+
+### 4. Start the services
+
+```bash
+podman-compose up -d
+```
+
+The first run builds the API image and pulls the PostGIS image (~2–3 minutes). On startup the API container:
+
+1. Reads `*.schema.yaml` files from `schemas/`
+2. Generates `models.py`, `app.py`, and `database.py`
+3. Connects to the PostGIS database (waits for it to be healthy)
+4. Creates all tables via SQLModel
+5. Starts uvicorn on port 8000
+
+### 5. Verify
+
+```bash
+# Check that both containers are running
+podman-compose ps
+
+# View API logs
+podman-compose logs api
+
+# Test the API
+curl http://localhost:8000/docs
+```
+
+The interactive API docs are at **http://localhost:8000/docs**.
+
+## Updating schemas
+
+When you change or add schemas, rebuild the API image and restart:
+
+```bash
+podman-compose build api
+podman-compose up -d api
+```
+
+## Stopping and cleaning up
+
+```bash
+# Stop containers (data is preserved in ./postgres/)
+podman-compose down
+
+# Stop and delete all data volumes (destructive)
+podman-compose down -v
+rm -rf ./postgres/
+```
+
+## Connecting to the database directly
+
+The PostgreSQL service is exposed on port 5432. Connect from the host with:
+
+```bash
+psql -h localhost -p 5432 -U postgres -d mydb
+```
+
+Or use pgAdmin — see the [podgis](../podgis) repo for a pgAdmin setup example using the same network pattern.
+
+## Network layout
+
+Both services share a private bridge network (`app_network`):
+
+| Service | IP | Port |
+|---------|----|------|
+| `postgres` | `10.91.0.5` | `5432` |
+| `api` | `10.91.0.6` | `8000` |
+
+The API connects to postgres using the service alias `postgres` as the hostname (via `DATABASE_URL`).
+
+## Environment variable reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `POSTGRES_USER` | — | PostgreSQL superuser name |
+| `POSTGRES_PASSWORD` | — | PostgreSQL superuser password |
+| `POSTGRES_DB` | — | Database name to create on first run |
+| `DATABASE_URL` | *(set by compose)* | SQLAlchemy connection URL; automatically constructed from the postgres credentials |
+| `API_KEY` | *(unset)* | If set, all API requests require `X-API-Key: <value>` header |
+| `ALLOWED_ORIGINS` | `*` | Comma-separated CORS allowed origins |
+| `API_URL` | `http://localhost:8000` | Public base URL (used by the Excel export endpoint) |

--- a/podman/compose.yaml
+++ b/podman/compose.yaml
@@ -1,0 +1,59 @@
+# compose.yaml
+#
+# Two services: PostGIS database and the generated FastAPI application.
+# Copy this file, Dockerfile, entrypoint.sh, and .env.example to your
+# deployment folder, then follow the README to get started.
+
+services:
+  postgres:
+    image: docker.io/postgis/postgis
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    volumes:
+      - ./postgres:/var/lib/postgresql/data:Z
+    ports:
+      - 5432:5432
+    networks:
+      app_network:
+        ipv4_address: 10.91.0.5
+        aliases:
+          - postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-*}
+      - API_KEY=${API_KEY}
+      - SCHEMA_FOLDER=/schemas
+      - API_URL=${API_URL:-http://localhost:8000}
+    volumes:
+      - ./schemas:/schemas:Z
+    ports:
+      - 8000:8000
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      app_network:
+        ipv4_address: 10.91.0.6
+        aliases:
+          - api
+
+networks:
+  app_network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.91.0.0/16
+          ip_range: 10.91.0.0/24
+          gateway: 10.91.0.1

--- a/podman/entrypoint.sh
+++ b/podman/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+SCHEMA_DIR="${SCHEMA_FOLDER:-/schemas}"
+
+echo "Generating FastAPI application from schemas in ${SCHEMA_DIR}..."
+mkdir -p /app/api
+fastapifromfrictionless generate "${SCHEMA_DIR}" --output /app/api
+touch /app/api/__init__.py
+
+echo "Starting API server on port 8000..."
+cd /app
+exec uvicorn api.app:app --host 0.0.0.0 --port 8000

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,9 @@
+## 2026-05-14 — Issue #54: Podman deployment
+
+Added `podman/` folder with six files: `compose.yaml` (two services — `postgres` using `docker.io/postgis/postgis` and `api` built from the local Dockerfile; shared bridge network `10.91.0.0/16` with static IPs following the podgis pattern), `Dockerfile` (Python 3.12-slim, installs `fastapifromfrictionless`, `uvicorn[standard]`, `psycopg2-binary`), `entrypoint.sh` (generates app files from mounted `/schemas` volume into `/app/api/` package at startup, then runs `uvicorn api.app:app`), `.env.example` (documents all env vars), `.gitignore` (ignores `.env` and `postgres/`), and `README.md` (setup instructions). The generated code uses relative imports so the entrypoint creates `api/__init__.py` to make the output directory a proper Python package before uvicorn starts.
+
+---
+
 ## 2026-05-13 — Issue #52: Expand documentation
 
 Rewrote README Quick Start with six numbered sections: CLI usage, starting the app, endpoint table per resource (POST, GET/all, GET/recent, GET/{pk}, PATCH, DELETE, GET/query, GET/excel/export, POST/excel/import), env var configuration table (DATABASE_URL, ALLOWED_ORIGINS, API_KEY, SCHEMA_FOLDER, API_URL), Excel workflow code examples, and CLI reference. Added jinja2 to Requirements list. Updated Core capabilities. No code changes.


### PR DESCRIPTION
## Summary

- Adds `podman/compose.yaml` with two services: `postgres` (PostGIS) and `api` (FastAPI built from local Dockerfile), on a dedicated bridge network (`10.91.0.0/16`) following the same static-IP pattern as the `podgis` repo
- Adds `podman/Dockerfile` — Python 3.12-slim, installs `fastapifromfrictionless`, `uvicorn[standard]`, `psycopg2-binary`
- Adds `podman/entrypoint.sh` — at container startup, generates `models.py`/`app.py`/`database.py` from mounted schemas into a `api/` package directory, then runs `uvicorn api.app:app` (the `api/` subdirectory with `__init__.py` is required because the generated code uses relative imports)
- Adds `podman/.env.example`, `podman/.gitignore`, `podman/schemas/` placeholder, and `podman/README.md`

## Usage

```bash
cd podman/
cp .env.example .env    # fill in passwords
# drop *.schema.yaml files into schemas/
podman-compose up -d
```

API docs available at http://localhost:8000/docs.

## Test plan

- [ ] Copy `podman/` contents to a test directory
- [ ] Add schema files from `doc/data/` to `schemas/`
- [ ] Fill in `.env` with a postgres password
- [ ] Run `podman-compose up -d` and confirm both containers start
- [ ] Confirm `curl http://localhost:8000/docs` returns the OpenAPI UI
- [ ] Confirm CRUD endpoints are present for each schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)