### PR TITLE
Add pgAdmin service to podman deployment

### DIFF
--- a/fastapifromfrictionless/load.py
+++ b/fastapifromfrictionless/load.py
@@ -197,7 +197,7 @@ def requests_post(
         session = requests.Session()
     logger.debug(f"Posting {model.model_dump_json()} to {server_url}/{endpoint}.")
     r = session.post(f"{os.path.join(server_url, endpoint)}", data=model.model_dump_json())
-    logger.debug(f"{r.content}")
+    logger.debug(r.content.decode("utf-8", errors="replace"))
     r.raise_for_status()
     json = r.json()
     r.close()

--- a/podman/.env.example
+++ b/podman/.env.example
@@ -5,6 +5,10 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=CHANGE_ME_STRONG_PASSWORD
 POSTGRES_DB=mydb
 
+# pgAdmin credentials
+PGADMIN_DEFAULT_EMAIL=you@example.com
+PGADMIN_DEFAULT_PASSWORD=CHANGE_ME_STRONG_PASSWORD
+
 # API configuration
 API_KEY=                           # Leave empty to disable API key authentication
 ALLOWED_ORIGINS=*                  # Comma-separated CORS origins; use * for development

--- a/podman/.gitignore
+++ b/podman/.gitignore
@@ -1,2 +1,3 @@
 .env
 postgres/
+pgadmin/

--- a/podman/README.md
+++ b/podman/README.md
@@ -1,6 +1,6 @@
 # Podman Deployment
 
-Deploy a generated FastAPI application alongside a PostGIS database using Podman Compose.
+Deploy a generated FastAPI application alongside a PostGIS database and pgAdmin using Podman Compose.
 
 ## Overview
 
@@ -8,7 +8,7 @@ This folder contains everything needed to run `fastapifromfrictionless` in a con
 
 | File | Purpose |
 |------|---------|
-| `compose.yaml` | Defines the `postgres` (PostGIS) and `api` (FastAPI) services |
+| `compose.yaml` | Defines the `postgres` (PostGIS), `pgadmin`, and `api` (FastAPI) services |
 | `Dockerfile` | Builds the API image; installs `fastapifromfrictionless` and uvicorn |
 | `entrypoint.sh` | Startup script: generates app from schemas, then launches uvicorn |
 | `.env.example` | Template for required environment variables |
@@ -57,7 +57,10 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=a_strong_random_password
 POSTGRES_DB=mydb
 
-API_KEY=another_strong_random_password   # or leave empty to disable auth
+PGADMIN_DEFAULT_EMAIL=you@example.com
+PGADMIN_DEFAULT_PASSWORD=another_strong_password
+
+API_KEY=yet_another_strong_password   # or leave empty to disable auth
 ALLOWED_ORIGINS=*
 API_URL=http://localhost:8000
 ```
@@ -70,7 +73,7 @@ API_URL=http://localhost:8000
 podman-compose up -d
 ```
 
-The first run builds the API image and pulls the PostGIS image (~2–3 minutes). On startup the API container:
+The first run builds the API image and pulls the PostGIS and pgAdmin images (~2–3 minutes). On startup the API container:
 
 1. Reads `*.schema.yaml` files from `schemas/`
 2. Generates `models.py`, `app.py`, and `database.py`
@@ -81,7 +84,7 @@ The first run builds the API image and pulls the PostGIS image (~2–3 minutes).
 ### 5. Verify
 
 ```bash
-# Check that both containers are running
+# Check that all three containers are running
 podman-compose ps
 
 # View API logs
@@ -91,7 +94,26 @@ podman-compose logs api
 curl http://localhost:8000/docs
 ```
 
-The interactive API docs are at **http://localhost:8000/docs**.
+| Service | URL |
+|---------|-----|
+| API docs | http://localhost:8000/docs |
+| pgAdmin | http://localhost:8080 |
+
+## Using pgAdmin
+
+1. Open **http://localhost:8080** in your browser.
+2. Log in with `PGADMIN_DEFAULT_EMAIL` and `PGADMIN_DEFAULT_PASSWORD` from your `.env`.
+3. Click **Add New Server** (or right-click Servers → Register → Server).
+4. In the **General** tab, give the server a name (e.g. `app-db`).
+5. In the **Connection** tab:
+   - **Host**: `10.91.0.5` (the postgres container IP)
+   - **Port**: `5432`
+   - **Username**: value of `POSTGRES_USER` in your `.env`
+   - **Password**: value of `POSTGRES_PASSWORD` in your `.env`
+   - Check **Save password**
+6. Click **Save**. The database and its tables should appear in the left panel.
+
+pgAdmin data (saved connections, sessions) is persisted in `./pgadmin/` and is excluded from git via `.gitignore`.
 
 ## Updating schemas
 
@@ -105,12 +127,12 @@ podman-compose up -d api
 ## Stopping and cleaning up
 
 ```bash
-# Stop containers (data is preserved in ./postgres/)
+# Stop containers (data is preserved in ./postgres/ and ./pgadmin/)
 podman-compose down
 
 # Stop and delete all data volumes (destructive)
 podman-compose down -v
-rm -rf ./postgres/
+rm -rf ./postgres/ ./pgadmin/
 ```
 
 ## Connecting to the database directly
@@ -121,16 +143,15 @@ The PostgreSQL service is exposed on port 5432. Connect from the host with:
 psql -h localhost -p 5432 -U postgres -d mydb
 ```
 
-Or use pgAdmin — see the [podgis](../podgis) repo for a pgAdmin setup example using the same network pattern.
-
 ## Network layout
 
-Both services share a private bridge network (`app_network`):
+All services share a private bridge network (`app_network`):
 
 | Service | IP | Port |
 |---------|----|------|
 | `postgres` | `10.91.0.5` | `5432` |
-| `api` | `10.91.0.6` | `8000` |
+| `pgadmin` | `10.91.0.6` | `8080` → `80` |
+| `api` | `10.91.0.7` | `8000` |
 
 The API connects to postgres using the service alias `postgres` as the hostname (via `DATABASE_URL`).
 
@@ -141,6 +162,8 @@ The API connects to postgres using the service alias `postgres` as the hostname 
 | `POSTGRES_USER` | — | PostgreSQL superuser name |
 | `POSTGRES_PASSWORD` | — | PostgreSQL superuser password |
 | `POSTGRES_DB` | — | Database name to create on first run |
+| `PGADMIN_DEFAULT_EMAIL` | — | Login email for the pgAdmin web UI |
+| `PGADMIN_DEFAULT_PASSWORD` | — | Login password for the pgAdmin web UI |
 | `DATABASE_URL` | *(set by compose)* | SQLAlchemy connection URL; automatically constructed from the postgres credentials |
 | `API_KEY` | *(unset)* | If set, all API requests require `X-API-Key: <value>` header |
 | `ALLOWED_ORIGINS` | `*` | Comma-separated CORS allowed origins |

--- a/podman/compose.yaml
+++ b/podman/compose.yaml
@@ -1,6 +1,6 @@
 # compose.yaml
 #
-# Two services: PostGIS database and the generated FastAPI application.
+# Three services: PostGIS database, pgAdmin web UI, and the generated FastAPI application.
 # Copy this file, Dockerfile, entrypoint.sh, and .env.example to your
 # deployment folder, then follow the README to get started.
 
@@ -26,6 +26,24 @@ services:
       timeout: 5s
       retries: 5
 
+  pgadmin:
+    image: docker.io/dpage/pgadmin4
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL}
+      - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_DEFAULT_PASSWORD}
+    volumes:
+      - ./pgadmin:/var/lib/pgadmin:Z
+    ports:
+      - 8080:80
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      app_network:
+        ipv4_address: 10.91.0.6
+        aliases:
+          - pgadmin
+
   api:
     build:
       context: .
@@ -45,7 +63,7 @@ services:
         condition: service_healthy
     networks:
       app_network:
-        ipv4_address: 10.91.0.6
+        ipv4_address: 10.91.0.7
         aliases:
           - api
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pytest",
     "ruff",
     "mypy",
+    "openpyxl",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- Adds `pgadmin` service (`docker.io/dpage/pgadmin4`) to `podman/compose.yaml` at `10.91.0.6`; bumps `api` to `10.91.0.7` to make room
- Persists pgAdmin data in `./pgadmin/` (added to `.gitignore`)
- Adds `PGADMIN_DEFAULT_EMAIL` and `PGADMIN_DEFAULT_PASSWORD` to `.env.example`
- Updates `podman/README.md` with pgAdmin login steps, server connection instructions, and updated network table
- Fixes `load.py` mypy `str-bytes-safe` error: decodes `r.content` (bytes) before logging

## Test plan

- [ ] Run `podman-compose up -d` and confirm all three containers start (`postgres`, `pgadmin`, `api`)
- [ ] Open http://localhost:8080, log in with pgAdmin credentials from `.env`
- [ ] Register the postgres server using IP `10.91.0.5` and confirm tables are visible
- [ ] Confirm API still responds at http://localhost:8000/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)