### PR TITLE
Release 0.2.0

### DIFF
--- a/fastapifromfrictionless/__init__.py
+++ b/fastapifromfrictionless/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 import logging
 


### PR DESCRIPTION
## Summary

- Bumps version from `0.1.0` to `0.2.0`

## Changes since v0.1.0

- **Podman deployment**: multi-stage Dockerfile, Compose stack with PostGIS + pgAdmin, configurable `SCHEMA_FOLDER` env var
- **Dependency restructuring**: `frictionless` and `jinja2` moved to optional `[generate]` extra — the base install is now leaner for runtime-only deployments
- **Bug fixes**: mypy `str-bytes-safe` fix in `load.py`, ruff F821 fix for lazy-imported return annotation, dead import cleanup

## Test plan

- [ ] CI passes (ruff + mypy + pytest)
- [ ] PyPI publish workflow triggers on merge tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)