### PR TITLE
Pre-built base images for faster Podman deployment

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,51 @@
+name: Build and push base images
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  GENERATOR_IMAGE: ghcr.io/${{ github.repository_owner }}/fastapi-from-frictionless-generator
+  RUNTIME_IMAGE: ghcr.io/${{ github.repository_owner }}/fastapi-from-frictionless-runtime
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from release tag
+        id: version
+        run: echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push generator base image
+        uses: docker/build-push-action@v6
+        with:
+          context: podman
+          file: podman/Dockerfile.generator-base
+          push: true
+          tags: |
+            ${{ env.GENERATOR_IMAGE }}:latest
+            ${{ env.GENERATOR_IMAGE }}:${{ steps.version.outputs.tag }}
+
+      - name: Build and push runtime base image
+        uses: docker/build-push-action@v6
+        with:
+          context: podman
+          file: podman/Dockerfile.runtime-base
+          push: true
+          tags: |
+            ${{ env.RUNTIME_IMAGE }}:latest
+            ${{ env.RUNTIME_IMAGE }}:${{ steps.version.outputs.tag }}

--- a/podman/Dockerfile
+++ b/podman/Dockerfile
@@ -1,12 +1,10 @@
 # Stage 1 — generate the FastAPI application from schemas
 #
-# Installs the full [generate] extras (includes frictionless + jinja2) and
-# runs the CLI against the schemas/ folder.  Nothing from this stage carries
-# into the final image.
-FROM python:3.12-slim AS generator
+# Uses the pre-built generator image (deps already installed).
+# Copies schemas into /schemas and runs the CLI to produce /generator/api/.
+# Nothing from this stage carries into the final image.
+FROM ghcr.io/jinskeep-morpc/fastapi-from-frictionless-generator:latest AS generator
 ARG SCHEMA_FOLDER=schemas
-WORKDIR /generator
-RUN pip install --no-cache-dir "fastapifromfrictionless[generate]"
 COPY ${SCHEMA_FOLDER}/ /schemas/
 RUN mkdir -p /generator/api && \
     python -m fastapifromfrictionless.cli generate /schemas --output /generator/api && \
@@ -14,17 +12,10 @@ RUN mkdir -p /generator/api && \
 
 # Stage 2 — lean runtime image
 #
-# Installs only the packages the generated app needs at runtime.
-# frictionless and jinja2 are intentionally excluded — they are only
-# required for code generation, which already happened in Stage 1.
-FROM python:3.12-slim
-WORKDIR /app
-RUN pip install --no-cache-dir \
-    fastapifromfrictionless \
-    "uvicorn[standard]" \
-    psycopg2-binary
-
-# Copy the pre-generated app from the generator stage
+# Uses the pre-built runtime image (deps already installed).
+# frictionless and jinja2 are intentionally excluded — code generation
+# already happened in Stage 1.
+FROM ghcr.io/jinskeep-morpc/fastapi-from-frictionless-runtime:latest
 COPY --from=generator /generator/api/ /app/api/
 
 EXPOSE 8000

--- a/podman/Dockerfile.generator-base
+++ b/podman/Dockerfile.generator-base
@@ -1,0 +1,3 @@
+FROM python:3.12-slim
+WORKDIR /generator
+RUN pip install --no-cache-dir "fastapifromfrictionless[generate]"

--- a/podman/Dockerfile.runtime-base
+++ b/podman/Dockerfile.runtime-base
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+RUN pip install --no-cache-dir \
+    fastapifromfrictionless \
+    "uvicorn[standard]" \
+    psycopg2-binary

--- a/podman/README.md
+++ b/podman/README.md
@@ -71,15 +71,17 @@ API_URL=http://localhost:8000
 
 The API image uses a **two-stage build**: Stage 1 generates the FastAPI application from your schemas; Stage 2 produces a lean runtime image without the generation tools.
 
+Both stages pull **pre-built base images** from ghcr.io that already have all Python dependencies installed. Your build only runs the `COPY` and code-generation steps — no pip installs.
+
 ```bash
-# Build the API image (reads schemas/ and generates the app code)
+# Build the API image (pulls pre-built bases, copies schemas, generates app code)
 podman-compose build api
 
 # Start all three services
 podman-compose up -d
 ```
 
-The first run pulls the PostGIS and pgAdmin images and builds the API image (~3–5 minutes). Subsequent builds are fast because the heavy pip install layer is cached.
+The first run pulls the PostGIS, pgAdmin, and pre-built base images (~1–2 min on a fast connection). Subsequent builds are very fast — the base images are cached locally.
 
 On startup the API container:
 
@@ -149,6 +151,25 @@ The PostgreSQL service is exposed on port 5432. Connect from the host with:
 
 ```bash
 psql -h localhost -p 5432 -U postgres -d mydb
+```
+
+## Pre-built base images
+
+The `Dockerfile` references two images published to the GitHub Container Registry:
+
+| Image | Tag | Purpose |
+|-------|-----|---------|
+| `ghcr.io/jinskeep-morpc/fastapi-from-frictionless-generator` | `latest` | Stage 1 base — `python:3.12-slim` + `fastapifromfrictionless[generate]` |
+| `ghcr.io/jinskeep-morpc/fastapi-from-frictionless-runtime` | `latest` | Stage 2 base — `python:3.12-slim` + `fastapifromfrictionless` + `uvicorn` + `psycopg2-binary` |
+
+These images are rebuilt automatically on each GitHub release via `.github/workflows/build-images.yml`. Both `latest` and version-pinned tags (e.g. `0.2.0`) are published.
+
+To pin to a specific version, edit the `FROM` lines in `Dockerfile`:
+
+```dockerfile
+FROM ghcr.io/jinskeep-morpc/fastapi-from-frictionless-generator:0.2.0 AS generator
+...
+FROM ghcr.io/jinskeep-morpc/fastapi-from-frictionless-runtime:0.2.0
 ```
 
 ## Network layout


### PR DESCRIPTION
Closes #63

## Summary

- Adds `.github/workflows/build-images.yml` — builds and pushes two base images to ghcr.io on each release
- Adds `podman/Dockerfile.generator-base` and `podman/Dockerfile.runtime-base` — source for those images
- Updates `podman/Dockerfile` to pull from the pre-built images instead of re-running pip from scratch
- Updates `podman/README.md` with a "Pre-built base images" section and revised build step description

## How it works

On release, the workflow pushes:
- `ghcr.io/jinskeep-morpc/fastapi-from-frictionless-generator:latest` (+ version tag)
- `ghcr.io/jinskeep-morpc/fastapi-from-frictionless-runtime:latest` (+ version tag)

End-user `podman-compose build api` pulls these cached images and only runs the `COPY` + `generate` steps — no pip installs, ~20 s instead of ~3 min.

## Test plan

- [ ] CI passes
- [ ] After merge, create a release to trigger `build-images.yml` and verify both images appear on ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)