### PR TITLE
Release 0.2.2

### DIFF
--- a/fastapifromfrictionless/__init__.py
+++ b/fastapifromfrictionless/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 import logging
 


### PR DESCRIPTION
## Summary

Bumps version to `0.2.2`.

## Changes since v0.2.1

- README endpoint table uses `/{resource}` placeholder instead of `/sensor`
- Updated quickstart notebook and README deployment docs for build-time generation workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)