### PR TITLE
Fix KeyError on 'any' and 'yearmonth' Frictionless field types

### DIFF
--- a/fastapifromfrictionless/model.py
+++ b/fastapifromfrictionless/model.py
@@ -29,9 +29,11 @@ type_map = {
     "date": {"default": "date"},
     "time": {"default": "time"},
     "year": {"default": "int"},
+    "yearmonth": {"default": "str"},
     "duration": {"default": "timedelta"},
     "geopoint": {"default": "Geometry('POINT')"},
     "geojson": {"default": "Geometry('GEOMETRY')"},
+    "any": {"default": "Any"},
 }
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
@@ -144,7 +146,8 @@ class models:
                 continue
 
             field_string = f"{field.name}: "
-            field_string += f"{type_map[field.type][field.format]}"
+            fmt_map = type_map.get(field.type, {"default": "Any"})
+            field_string += fmt_map.get(field.format, fmt_map["default"])
 
             if "required" not in field.constraints:
                 field_string += " | None"

--- a/tests/test_models_generator.py
+++ b/tests/test_models_generator.py
@@ -206,3 +206,49 @@ def test_save_writes_file(simple_folder, tmp_path):
     content = out.read_text()
     assert "LocationBase" in content
     assert "from sqlmodel import" in content
+
+
+# ---------------------------------------------------------------------------
+# type_map coverage — regression tests for missing / unknown types
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def any_yearmonth_folder(tmp_path):
+    write_schema(
+        tmp_path,
+        "item",
+        """\
+        fields:
+          - name: id
+            type: integer
+          - name: payload
+            type: any
+          - name: period
+            type: yearmonth
+          - name: link
+            type: string
+            format: uri
+        primaryKey:
+          - id
+        """,
+    )
+    return tmp_path
+
+
+def test_any_type_maps_to_Any(any_yearmonth_folder, tmp_path):
+    out = tmp_path / "models.py"
+    models(folder_str(any_yearmonth_folder)).build().save(out)
+    assert "payload: Any" in out.read_text()
+
+
+def test_yearmonth_type_maps_to_str(any_yearmonth_folder, tmp_path):
+    out = tmp_path / "models.py"
+    models(folder_str(any_yearmonth_folder)).build().save(out)
+    assert "period: str" in out.read_text()
+
+
+def test_string_uri_format_maps_to_AnyUrl(any_yearmonth_folder, tmp_path):
+    out = tmp_path / "models.py"
+    models(folder_str(any_yearmonth_folder)).build().save(out)
+    assert "link: AnyUrl" in out.read_text()


### PR DESCRIPTION
Closes #73

## Problem

Deploying with a schema that includes a field of type `any` crashes:

```
KeyError: 'any'
  File ".../model.py", line 147, in build_model
    field_string += f"{type_map[field.type][field.format]}"
```

`type_map` was missing two Frictionless types (`any`, `yearmonth`), and the format lookup crashed on any unrecognized format string instead of falling back gracefully.

## Fix

- Added `"any": {"default": "Any"}` and `"yearmonth": {"default": "str"}` to `type_map`
- Changed the lookup from `type_map[field.type][field.format]` to `.get()` calls so unknown formats fall back to the type's `"default"` entry
- Added 3 regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)