### PR TITLE
Release 0.2.3

### DIFF
--- a/fastapifromfrictionless/__init__.py
+++ b/fastapifromfrictionless/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 import logging
 


### PR DESCRIPTION
## Summary

Bumps version to `0.2.3`.

## Changes since v0.2.2

- **Bug fix**: `KeyError` crash on Frictionless `any` and `yearmonth` field types; unknown formats now fall back gracefully to the type default
- **README**: updated Podman roadmap item to reflect full current state (pgAdmin, multi-stage build, pre-built images on ghcr.io)

🤖 Generated with [Claude Code](https://claude.com/claude-code)