### PR TITLE
Fix IndentationError on schemas with no base fields

### DIFF
--- a/fastapifromfrictionless/templates/model_block.py.jinja2
+++ b/fastapifromfrictionless/templates/model_block.py.jinja2
@@ -2,7 +2,11 @@
 
 ## << name >> models
 class << name >>Base(SQLModel):
+<% if basemodel_fields_str %>
     << basemodel_fields_str >>
+<% else %>
+    pass
+<% endif %>
 
 class << name >>(<< name >>Base, TimestampMixin, table=True):
 <% if auto_id %>
@@ -22,7 +26,11 @@ class << name >>Create(<< name >>Base):
     pass
 
 class << name >>Update(<< name >>Base):
+<% if update_fields_str %>
 << update_fields_str >>
+<% else %>
+    pass
+<% endif %>
 
 class << name >>Public(<< name >>Base):
 <% if auto_id %>

--- a/tests/test_models_generator.py
+++ b/tests/test_models_generator.py
@@ -236,6 +236,41 @@ def any_yearmonth_folder(tmp_path):
     return tmp_path
 
 
+@pytest.fixture()
+def id_only_folder(tmp_path):
+    write_schema(
+        tmp_path,
+        "respondent",
+        """\
+        fields:
+          - name: id
+            type: integer
+            constraints:
+              required: true
+        primaryKey:
+          - id
+        """,
+    )
+    return tmp_path
+
+
+def test_id_only_schema_generates_valid_python(id_only_folder, tmp_path):
+    import ast
+
+    out = tmp_path / "models.py"
+    models(folder_str(id_only_folder)).build().save(out)
+    ast.parse(out.read_text())  # raises SyntaxError if invalid
+
+
+def test_id_only_base_has_pass(id_only_folder, tmp_path):
+    out = tmp_path / "models.py"
+    models(folder_str(id_only_folder)).build().save(out)
+    content = out.read_text()
+    # RespondentBase and RespondentUpdate must both have a body
+    assert "class RespondentBase(SQLModel):\n    pass" in content
+    assert "class RespondentUpdate(RespondentBase):\n    pass" in content
+
+
 def test_any_type_maps_to_Any(any_yearmonth_folder, tmp_path):
     out = tmp_path / "models.py"
     models(folder_str(any_yearmonth_folder)).build().save(out)


### PR DESCRIPTION
Closes #78

## Problem

A schema whose only field is `id` (with `auto_id=True`) generates an empty `Base` and `Update` class body — invalid Python that crashes uvicorn at startup:

```
IndentationError: expected an indented block after class definition on line 31
```

## Fix

Template now emits `pass` when `basemodel_fields_str` or `update_fields_str` is empty.

## Tests

Added two regression tests:
- `test_id_only_schema_generates_valid_python` — parses generated output with `ast.parse`
- `test_id_only_base_has_pass` — asserts `pass` appears in `RespondentBase` and `RespondentUpdate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)