### PR TITLE
Release 0.2.4

### DIFF
--- a/fastapifromfrictionless/__init__.py
+++ b/fastapifromfrictionless/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 
 import logging
 


### PR DESCRIPTION
## Summary

Bumps version to `0.2.4`.

## Changes since v0.2.3

- **Bug fix**: `IndentationError` crash at uvicorn startup when a schema has no fields in its base class (e.g. an id-only schema). Template now emits `pass` for empty `Base` and `Update` class bodies.
- **Workflow fix**: base images now build after PyPI publish completes (race condition fix), with manual `workflow_dispatch` support for re-triggering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)