### PR TITLE
fix: add geoalchemy2 to deps and conditionally import only for geo schemas

### DIFF
--- a/fastapifromfrictionless/model.py
+++ b/fastapifromfrictionless/model.py
@@ -82,6 +82,7 @@ class models:
             model = self.build_model(self.folder, filename)
             self.models.append(model)
 
+        self.has_geo = any("Geometry" in m for m in self.models)
         return self
 
     def build_model(self, folder: str, filename: str) -> str:
@@ -209,7 +210,9 @@ class models:
         return result
 
     def save(self, path: str | PathLike):
-        header = _env.get_template("models_header.py.jinja2").render()
+        header = _env.get_template("models_header.py.jinja2").render(
+            has_geo=getattr(self, "has_geo", True)
+        )
         with open(path, "w") as file:
             file.write(header + "".join(self.models))
             logger.info(f"models saved to {path}")

--- a/fastapifromfrictionless/templates/models_header.py.jinja2
+++ b/fastapifromfrictionless/templates/models_header.py.jinja2
@@ -5,7 +5,9 @@ from sqlalchemy import DateTime
 from sqlmodel import Field, Relationship, SQLModel
 from datetime import date, datetime, timezone, time, timedelta
 from pydantic import EmailStr, AnyUrl, Json
+<% if has_geo %>
 from geoalchemy2.types import Geometry
+<% endif %>
 
 def utcnow():
     '''Returns the current time in UTC.'''

--- a/podman/Dockerfile.runtime-base
+++ b/podman/Dockerfile.runtime-base
@@ -3,4 +3,5 @@ WORKDIR /app
 RUN pip install --no-cache-dir \
     fastapifromfrictionless \
     "uvicorn[standard]" \
-    psycopg2-binary
+    psycopg2-binary \
+    geoalchemy2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "fastapi_querybuilder",
     "sqlalchemy",
     "xlsxwriter",
+    "geoalchemy2",
 ]
 
 [project.optional-dependencies]

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,6 @@
+## 2026-05-14 — Fix geoalchemy2 missing dependency (#81)
+
+Schemas without geo field types raised ModuleNotFoundError because models_header.py.jinja2 unconditionally imported from geoalchemy2. Added has_geo tracking in model.build() and made the import conditional in the template. Also added geoalchemy2 to pyproject.toml base dependencies and podman/Dockerfile.runtime-base so the runtime image includes it. 89 tests passing.
 ## Issue #66 — Update README and quickstart notebook
 
 Fixed docs that became stale after the multi-stage Dockerfile (#60) and pre-built base images (#63):
@@ -161,4 +164,5 @@ Added `dump_to_excel(api_url, schema_folder, output_filepath)` to `load.py`. Fet
 Rewrote README to replace the rough WIP checklist with a proper package overview, requirements list, Quick Start, and a structured production roadmap (Foundation → Code Quality → Production Readiness → Developer Experience → Optional). Also added CLAUDE.md with the 9-step development workflow and coding guidelines. No code changes.
 
 ---
+
 

--- a/tests/test_models_generator.py
+++ b/tests/test_models_generator.py
@@ -287,3 +287,38 @@ def test_string_uri_format_maps_to_AnyUrl(any_yearmonth_folder, tmp_path):
     out = tmp_path / "models.py"
     models(folder_str(any_yearmonth_folder)).build().save(out)
     assert "link: AnyUrl" in out.read_text()
+
+
+# ---------------------------------------------------------------------------
+# geoalchemy2 conditional import
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def geo_folder(tmp_path):
+    write_schema(
+        tmp_path,
+        "site",
+        """\
+        fields:
+          - name: id
+            type: integer
+          - name: location
+            type: geopoint
+        primaryKey:
+          - id
+        """,
+    )
+    return tmp_path
+
+
+def test_geo_schema_includes_geoalchemy2_import(geo_folder, tmp_path):
+    out = tmp_path / "models.py"
+    models(folder_str(geo_folder)).build().save(out)
+    assert "from geoalchemy2.types import Geometry" in out.read_text()
+
+
+def test_non_geo_schema_omits_geoalchemy2_import(simple_folder, tmp_path):
+    out = tmp_path / "models.py"
+    models(folder_str(simple_folder)).build().save(out)
+    assert "geoalchemy2" not in out.read_text()


### PR DESCRIPTION
## Summary

- `geoalchemy2` added to `pyproject.toml` base dependencies so it is always installed
- `podman/Dockerfile.runtime-base` now installs `geoalchemy2`
- `model.build()` tracks whether any model uses `Geometry` via `has_geo` flag
- `models_header.py.jinja2` only emits the `geoalchemy2` import when `has_geo` is True
- Two regression tests added: geo schema includes the import, non-geo schema omits it

## Test plan

- [ ] `pytest` passes (89 tests)
- [ ] Non-geo schema does not import geoalchemy2
- [ ] Geo schema imports geoalchemy2

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)