### PR TITLE
fix: add Any to typing imports in generated models header

### DIFF
--- a/fastapifromfrictionless/templates/models_header.py.jinja2
+++ b/fastapifromfrictionless/templates/models_header.py.jinja2
@@ -1,5 +1,5 @@
 
-from typing import Optional, List
+from typing import Any, Optional, List
 from uuid import UUID
 from sqlalchemy import DateTime
 from sqlmodel import Field, Relationship, SQLModel

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,6 @@
+## 2026-05-14 — Fix NameError: Any not imported in generated models header (#85)
+
+The models_header.py.jinja2 template imported Optional and List from typing but not Any, causing NameError at startup for schemas with field types 'any', 'object', or 'array'. Added Any to the import. 90 tests passing.
 ## 2026-05-14 — Fix geoalchemy2 missing dependency (#81)
 
 Schemas without geo field types raised ModuleNotFoundError because models_header.py.jinja2 unconditionally imported from geoalchemy2. Added has_geo tracking in model.build() and made the import conditional in the template. Also added geoalchemy2 to pyproject.toml base dependencies and podman/Dockerfile.runtime-base so the runtime image includes it. 89 tests passing.

--- a/tests/test_models_generator.py
+++ b/tests/test_models_generator.py
@@ -277,6 +277,12 @@ def test_any_type_maps_to_Any(any_yearmonth_folder, tmp_path):
     assert "payload: Any" in out.read_text()
 
 
+def test_header_imports_Any(simple_folder, tmp_path):
+    out = tmp_path / "models.py"
+    models(folder_str(simple_folder)).build().save(out)
+    assert "from typing import Any" in out.read_text()
+
+
 def test_yearmonth_type_maps_to_str(any_yearmonth_folder, tmp_path):
     out = tmp_path / "models.py"
     models(folder_str(any_yearmonth_folder)).build().save(out)


### PR DESCRIPTION
## Summary

- `from typing import Any` was missing from the header template
- Schemas with `any`, `object`, or `array` field types generate `Any` annotations but the import was absent, causing `NameError: name 'Any' is not defined` at startup
- One-line fix: add `Any` to the existing `typing` import
- Added regression test `test_header_imports_Any`

## Test plan

- [ ] `pytest` passes (90 tests)
- [ ] Schemas using `any`/`object`/`array` types no longer raise NameError

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)