### PR TITLE
fix: map Frictionless 'any' type to str instead of typing.Any

### DIFF
--- a/fastapifromfrictionless/model.py
+++ b/fastapifromfrictionless/model.py
@@ -33,7 +33,7 @@ type_map = {
     "duration": {"default": "timedelta"},
     "geopoint": {"default": "Geometry('POINT')"},
     "geojson": {"default": "Geometry('GEOMETRY')"},
-    "any": {"default": "Any"},
+    "any": {"default": "str"},
 }
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,6 @@
+## 2026-05-14 — Fix Frictionless 'any' type → typing.Any has no SQLAlchemy mapping (#89)
+
+Frictionless 'any' type was mapped to typing.Any in the type_map, but typing.Any has no SQLAlchemy column type, causing ValueError at startup for any schema with an 'any' field. Changed mapping to 'str' (stored as text). Updated the corresponding test. 90 tests passing.
 ## 2026-05-14 — Fix NameError: Any not imported in generated models header (#85)
 
 The models_header.py.jinja2 template imported Optional and List from typing but not Any, causing NameError at startup for schemas with field types 'any', 'object', or 'array'. Added Any to the import. 90 tests passing.

--- a/tests/test_models_generator.py
+++ b/tests/test_models_generator.py
@@ -271,10 +271,10 @@ def test_id_only_base_has_pass(id_only_folder, tmp_path):
     assert "class RespondentUpdate(RespondentBase):\n    pass" in content
 
 
-def test_any_type_maps_to_Any(any_yearmonth_folder, tmp_path):
+def test_any_type_maps_to_str(any_yearmonth_folder, tmp_path):
     out = tmp_path / "models.py"
     models(folder_str(any_yearmonth_folder)).build().save(out)
-    assert "payload: Any" in out.read_text()
+    assert "payload: str" in out.read_text()
 
 
 def test_header_imports_Any(simple_folder, tmp_path):


### PR DESCRIPTION
## Summary

- `type_map["any"]` changed from `"Any"` to `"str"`
- `typing.Any` has no SQLAlchemy column type, causing `ValueError` in `table=True` models
- `str` maps to VARCHAR/TEXT and is universally compatible
- Updated `test_any_type_maps_to_Any` → `test_any_type_maps_to_str`

## Test plan

- [ ] `pytest` passes (90 tests)
- [ ] Schema with `any` field generates `field: str | None` and starts without error

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)