### PR TITLE
fix: pin package version in base image builds to avoid PyPI CDN lag

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -49,12 +49,28 @@ jobs:
             echo "tag=${TAG#v}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Wait for version to be available on PyPI
+        run: |
+          VERSION="${{ steps.version.outputs.tag }}"
+          echo "Waiting for fastapifromfrictionless==${VERSION} on PyPI..."
+          for i in $(seq 1 24); do
+            if pip index versions fastapifromfrictionless 2>/dev/null | grep -q "${VERSION}"; then
+              echo "Version ${VERSION} is available."
+              exit 0
+            fi
+            echo "Attempt ${i}/24: not yet available, waiting 30s..."
+            sleep 30
+          done
+          echo "ERROR: Version ${VERSION} not visible on PyPI after 12 minutes."
+          exit 1
+
       - name: Build and push generator base image
         uses: docker/build-push-action@v6
         with:
           context: podman
           file: podman/Dockerfile.generator-base
           push: true
+          build-args: PACKAGE_VERSION=${{ steps.version.outputs.tag }}
           tags: |
             ${{ env.GENERATOR_IMAGE }}:latest
             ${{ env.GENERATOR_IMAGE }}:${{ steps.version.outputs.tag }}
@@ -65,6 +81,7 @@ jobs:
           context: podman
           file: podman/Dockerfile.runtime-base
           push: true
+          build-args: PACKAGE_VERSION=${{ steps.version.outputs.tag }}
           tags: |
             ${{ env.RUNTIME_IMAGE }}:latest
             ${{ env.RUNTIME_IMAGE }}:${{ steps.version.outputs.tag }}

--- a/podman/Dockerfile.generator-base
+++ b/podman/Dockerfile.generator-base
@@ -1,3 +1,4 @@
 FROM python:3.12-slim
+ARG PACKAGE_VERSION
 WORKDIR /generator
-RUN pip install --no-cache-dir "fastapifromfrictionless[generate]"
+RUN pip install --no-cache-dir "fastapifromfrictionless[generate]==${PACKAGE_VERSION}"

--- a/podman/Dockerfile.runtime-base
+++ b/podman/Dockerfile.runtime-base
@@ -1,7 +1,8 @@
 FROM python:3.12-slim
+ARG PACKAGE_VERSION
 WORKDIR /app
 RUN pip install --no-cache-dir \
-    fastapifromfrictionless \
+    "fastapifromfrictionless==${PACKAGE_VERSION}" \
     "uvicorn[standard]" \
     psycopg2-binary \
     geoalchemy2

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,6 @@
+## 2026-05-14 — Pin package version in base image builds to avoid PyPI CDN lag (#91)
+
+The Dockerfiles for base images installed fastapifromfrictionless without a version pin. When build-images.yml fired right after the PyPI publish, pip sometimes got the previous cached version. Added ARG PACKAGE_VERSION to both Dockerfiles and a PyPI polling step in the workflow that retries up to 12 minutes before starting the Docker builds. The workflow also now passes build-args: PACKAGE_VERSION=... to both builds.
 ## 2026-05-14 — Fix Frictionless 'any' type → typing.Any has no SQLAlchemy mapping (#89)
 
 Frictionless 'any' type was mapped to typing.Any in the type_map, but typing.Any has no SQLAlchemy column type, causing ValueError at startup for any schema with an 'any' field. Changed mapping to 'str' (stored as text). Updated the corresponding test. 90 tests passing.


### PR DESCRIPTION
## Summary

- `ARG PACKAGE_VERSION` added to both `Dockerfile.generator-base` and `Dockerfile.runtime-base`
- Both now install `fastapifromfrictionless==${PACKAGE_VERSION}` (pinned)
- `build-images.yml` workflow now polls PyPI every 30s (up to 12 min) to confirm the target version is available before starting the Docker builds
- Workflow passes `build-args: PACKAGE_VERSION=...` to both build steps

## Why

The workflow fired immediately when PyPI publish succeeded, but pip's CDN sometimes served the previous cached release for a few minutes afterward. This caused images to silently bake in the wrong package version.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)