### PR TITLE
fix: add python-multipart to runtime dependencies

### DIFF
--- a/podman/Dockerfile.runtime-base
+++ b/podman/Dockerfile.runtime-base
@@ -5,4 +5,5 @@ RUN pip install --no-cache-dir \
     "fastapifromfrictionless==${PACKAGE_VERSION}" \
     "uvicorn[standard]" \
     psycopg2-binary \
-    geoalchemy2
+    geoalchemy2 \
+    python-multipart

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "sqlalchemy",
     "xlsxwriter",
     "geoalchemy2",
+    "python-multipart",
 ]
 
 [project.optional-dependencies]

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,6 @@
+## 2026-05-14 — Fix python-multipart missing from runtime dependencies (#93)
+
+The Excel import endpoint uses FastAPI UploadFile which requires python-multipart at import time. Without it the app crashed at startup with RuntimeError. Added to pyproject.toml base deps and Dockerfile.runtime-base.
 ## 2026-05-14 — Pin package version in base image builds to avoid PyPI CDN lag (#91)
 
 The Dockerfiles for base images installed fastapifromfrictionless without a version pin. When build-images.yml fired right after the PyPI publish, pip sometimes got the previous cached version. Added ARG PACKAGE_VERSION to both Dockerfiles and a PyPI polling step in the workflow that retries up to 12 minutes before starting the Docker builds. The workflow also now passes build-args: PACKAGE_VERSION=... to both builds.


### PR DESCRIPTION
## Summary

- `python-multipart` added to `pyproject.toml` base dependencies
- `python-multipart` added to `podman/Dockerfile.runtime-base`

FastAPI's `UploadFile` (used by the `/excel/import` endpoint) checks for `python-multipart` at route registration time and raises `RuntimeError` immediately at startup if it's missing.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)