### PR TITLE
fix: guard generator imports in __init__.py behind try/except ImportError

### DIFF
--- a/fastapifromfrictionless/__init__.py
+++ b/fastapifromfrictionless/__init__.py
@@ -4,9 +4,15 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from .app import app
-from .database import database
 from .load import *
 from .logging_config import configure_logging
-from .model import models
-from .validate import assert_schemas_valid, validate_schemas
+
+# Generator classes require jinja2/frictionless ([generate] extra). Guard so
+# the base package is importable in runtime environments without those deps.
+try:
+    from .app import app
+    from .database import database
+    from .model import models
+    from .validate import assert_schemas_valid, validate_schemas
+except ImportError:
+    pass

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,6 @@
+## 2026-05-14 — Fix generator imports crashing runtime via __init__.py (#95)
+
+Generator classes (app, database, model, validate) all require jinja2/frictionless from the [generate] extra. But __init__.py imported them unconditionally, so import fastapifromfrictionless failed in runtime environments. Wrapped generator imports in try/except ImportError so the base package is importable without the extra. 90 tests passing.
 ## 2026-05-14 — Fix python-multipart missing from runtime dependencies (#93)
 
 The Excel import endpoint uses FastAPI UploadFile which requires python-multipart at import time. Without it the app crashed at startup with RuntimeError. Added to pyproject.toml base deps and Dockerfile.runtime-base.


### PR DESCRIPTION
## Summary

- Generator classes (`app`, `database`, `model`, `validate`) all need `jinja2`/`frictionless` from the `[generate]` extra
- They were imported unconditionally in `__init__.py`, so `import fastapifromfrictionless` failed in runtime environments (where only the base package is installed)
- Wrapped in `try/except ImportError` — base installs work fine, generator installs get all classes as before

## Impact

This caused the Excel export endpoint to crash at request time with `ModuleNotFoundError: No module named 'jinja2'` because the endpoint lazily does `from fastapifromfrictionless.load import dump_to_excel`.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)