### PR TITLE
fix: add frictionless to runtime dependencies for Excel export/import

### DIFF
--- a/podman/Dockerfile.runtime-base
+++ b/podman/Dockerfile.runtime-base
@@ -6,4 +6,5 @@ RUN pip install --no-cache-dir \
     "uvicorn[standard]" \
     psycopg2-binary \
     geoalchemy2 \
-    python-multipart
+    python-multipart \
+    frictionless

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "xlsxwriter",
     "geoalchemy2",
     "python-multipart",
+    "frictionless",
 ]
 
 [project.optional-dependencies]

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,6 @@
+## 2026-05-14 — Fix frictionless missing from runtime dependencies (#97)
+
+The Excel export/import endpoints use frictionless to read schema files for column headers and data loading. frictionless was only in the [generate] optional extra but is also needed at runtime. Added to pyproject.toml base deps and Dockerfile.runtime-base.
 ## 2026-05-14 — Fix generator imports crashing runtime via __init__.py (#95)
 
 Generator classes (app, database, model, validate) all require jinja2/frictionless from the [generate] extra. But __init__.py imported them unconditionally, so import fastapifromfrictionless failed in runtime environments. Wrapped generator imports in try/except ImportError so the base package is importable without the extra. 90 tests passing.


### PR DESCRIPTION
## Summary

- `frictionless` added to `pyproject.toml` base dependencies
- `frictionless` added to `podman/Dockerfile.runtime-base`

The Excel export/import endpoints call `dump_to_excel` and related `load.py` utilities which lazily `import frictionless` to read schema files for column headers. `frictionless` was only in the `[generate]` optional extra, causing `ModuleNotFoundError` at request time in runtime deployments.

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)