### PR TITLE
fix: install frictionless[excel] to include openpyxl for Excel import

### DIFF
--- a/podman/Dockerfile.runtime-base
+++ b/podman/Dockerfile.runtime-base
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir \
     psycopg2-binary \
     geoalchemy2 \
     python-multipart \
-    frictionless
+    "frictionless[excel]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "xlsxwriter",
     "geoalchemy2",
     "python-multipart",
-    "frictionless",
+    "frictionless[excel]",
 ]
 
 [project.optional-dependencies]

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,6 @@
+## 2026-05-14 — Fix frictionless[excel] missing openpyxl for Excel import (#99)
+
+frictionless base install does not include openpyxl (needed to read .xlsx files). Changed from frictionless to frictionless[excel] in pyproject.toml and Dockerfile.runtime-base.
 ## 2026-05-14 — Fix frictionless missing from runtime dependencies (#97)
 
 The Excel export/import endpoints use frictionless to read schema files for column headers and data loading. frictionless was only in the [generate] optional extra but is also needed at runtime. Added to pyproject.toml base deps and Dockerfile.runtime-base.


### PR DESCRIPTION
## Summary

- Changed `frictionless` → `frictionless[excel]` in `pyproject.toml` and `Dockerfile.runtime-base`
- `frictionless` base install omits `openpyxl`, which frictionless needs to read `.xlsx` files
- The Excel import endpoint was returning 500 with "invalid excel file" because `openpyxl` was absent

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)