### PR TITLE
fix: strip foreignKeys before standalone resource.infer() in create_package

### DIFF
--- a/fastapifromfrictionless/load.py
+++ b/fastapifromfrictionless/load.py
@@ -78,11 +78,15 @@ def create_package(folder: str | os.PathLike, filename: str | os.PathLike, valid
         for schema in schemas:
             logger.info(f"appending {schema} to package")
             schema_name = schema.replace(".schema.yaml", "")
+            # Strip foreign keys before standalone infer — frictionless requires the
+            # full package context to resolve cross-resource FK references.
+            schema_descriptor = frictionless.Schema.from_descriptor(schema).to_descriptor()
+            schema_descriptor.pop("foreignKeys", None)
             resource = TableResource(
                 name=schema_name,
                 path=filename_str,
                 control=ExcelControl(sheet=schema_name),
-                schema=(frictionless.Schema.from_descriptor(schema)),
+                schema=frictionless.Schema.from_descriptor(schema_descriptor),
                 dialect=frictionless.Dialect(skip_blank_rows=True),
             )
             resource.infer(stats=True)

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,6 @@
+## 2026-05-14 — Fix create_package FK error during standalone resource.infer() (#101)
+
+frictionless raises 'package is required for foreign keys' when infer() is called on a standalone TableResource with FK constraints. Strip foreignKeys from schema descriptor before infer; FK validation still happens at package level when validate=True.
 ## 2026-05-14 — Fix frictionless[excel] missing openpyxl for Excel import (#99)
 
 frictionless base install does not include openpyxl (needed to read .xlsx files). Changed from frictionless to frictionless[excel] in pyproject.toml and Dockerfile.runtime-base.


### PR DESCRIPTION
## Summary

`create_package` builds a frictionless `Package` by calling `resource.infer(stats=True)` on each `TableResource` individually before assembling them. frictionless raises `[resource-error] package is required for foreign keys to other resources` when a schema has FK constraints and no package context is available.

**Fix:** strip `foreignKeys` from the schema descriptor before `infer()`. FK constraints are still validated at the package level when `validate=True` is passed to `create_package`.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)