### PR TITLE
fix: quick wins #105 #106 #107 #108 #109

### DIFF
--- a/fastapifromfrictionless/load.py
+++ b/fastapifromfrictionless/load.py
@@ -226,6 +226,7 @@ def requests_get_all(
     url = f"{server_url.rstrip('/')}/{endpoint}/all"
     logger.debug(f"Getting all from at {url}")
     json = []
+    r = None
     try:
         r = session.get(url)
         r.raise_for_status()
@@ -237,7 +238,8 @@ def requests_get_all(
     except Exception as e:
         logger.error(f"Other Error: {e}")
     finally:
-        r.close()
+        if r is not None:
+            r.close()
 
     return pd.DataFrame.from_dict(json)
 

--- a/fastapifromfrictionless/load.py
+++ b/fastapifromfrictionless/load.py
@@ -204,7 +204,7 @@ def requests_post(
     if session is None:
         session = requests.Session()
     logger.debug(f"Posting {model.model_dump_json()} to {server_url}/{endpoint}.")
-    r = session.post(f"{os.path.join(server_url, endpoint)}", data=model.model_dump_json())
+    r = session.post(f"{server_url.rstrip('/')}/{endpoint}", data=model.model_dump_json())
     logger.debug(r.content.decode("utf-8", errors="replace"))
     r.raise_for_status()
     json = r.json()
@@ -223,7 +223,7 @@ def requests_get_all(
 
     if session is None:
         session = requests.Session()
-    url = f"{os.path.join(server_url, endpoint, 'all')}"
+    url = f"{server_url.rstrip('/')}/{endpoint}/all"
     logger.debug(f"Getting all from at {url}")
     json = []
     try:
@@ -253,7 +253,7 @@ def requests_update(
     if session is None:
         session = requests.Session()
     logger.debug(f"Updating {pk} at {server_url}/{endpoint} to {model.model_dump_json()}")
-    r = session.patch(f"{os.path.join(server_url, endpoint, pk)}", data=model.model_dump_json())
+    r = session.patch(f"{server_url.rstrip('/')}/{endpoint}/{pk}", data=model.model_dump_json())
     r.raise_for_status()
     json = r.json()
     r.close()

--- a/fastapifromfrictionless/load.py
+++ b/fastapifromfrictionless/load.py
@@ -332,12 +332,7 @@ def update_api_from_package(api_url, package_file, skip=[], api_key: str = ""):
                     current_row = current_all.loc[current_all[current_all.columns[0]] == row_pk]
                     current_row = current_row.loc[[x for x in current_row.index][0]].to_dict()
 
-                    for k, v in row.items():
-                        changed = False
-                        if current_row[k] == v:
-                            continue
-                        else:
-                            changed = True
+                    changed = any(current_row.get(k) != v for k, v in row.items())
 
                     # if it is changed, update.
                     if changed:

--- a/fastapifromfrictionless/model.py
+++ b/fastapifromfrictionless/model.py
@@ -162,10 +162,10 @@ class models:
             if field.name in foreign_keys:
                 if " = Field(primary_key = True)" in field_string:
                     field_string = (
-                        f"{field_string.rstrip(')')}, foreign_key='{field.name.replace('_', '.')}')"
+                        f"{field_string.rstrip(')')}, foreign_key='{field.name.replace('_', '.')}', index=True)"
                     )
                 else:
-                    field_string += f" = Field({'default=None, ' if required else ''}foreign_key='{field.name.replace('_', '.')}')"
+                    field_string += f" = Field({'default=None, ' if required else ''}foreign_key='{field.name.replace('_', '.')}', index=True)"
 
             self.logger.info(f"{field} converted to {field_string}")
             basemodel_fields.append(field_string)

--- a/fastapifromfrictionless/templates/app_header.py.jinja2
+++ b/fastapifromfrictionless/templates/app_header.py.jinja2
@@ -1,6 +1,7 @@
 
 # app.py
 import os
+import secrets
 import tempfile
 from pathlib import Path
 from fastapi import Depends, FastAPI, File, HTTPException, Query, Security, UploadFile
@@ -23,7 +24,7 @@ _API_KEY = os.getenv("API_KEY", "")
 _api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 async def verify_api_key(api_key: str = Security(_api_key_header)):
-    if _API_KEY and api_key != _API_KEY:
+    if _API_KEY and not secrets.compare_digest(api_key or "", _API_KEY):
         raise HTTPException(status_code=403, detail="Invalid or missing API key")
 
 # Excel file endpoints config

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,12 @@
+## fix/quick-wins-105-109
+
+Fixed 5 code-review quick wins in parallel via feature-team:
+- #105: change detection loop in update_api_from_package — now uses a single any() over row.items() so any field difference triggers an update (previous loop reset changed=False each iteration and only reflected the last field).
+- #106: generated FK SQLModel Fields now include index=True for query performance on JOINs and FK filters.
+- #107: API key check now uses secrets.compare_digest(api_key or "", _API_KEY) and the template imports secrets — eliminates timing side channel.
+- #108: requests_post/requests_get_all/requests_update build URLs with f-strings ({server_url.rstrip('/')}/{endpoint}/...) instead of os.path.join, which corrupted https:// schemes on POSIX.
+- #109: requests_get_all initializes r = None before the try and guards r.close() with if r is not None — prevents UnboundLocalError when the session.get(...) itself raises.
+
 ## 2026-05-14 — Fix create_package absolute path rejected as unsafe by frictionless (#103)
 
 frictionless rejects absolute paths during package.validate(). Changed create_package to chdir to the Excel file's directory and reference it by relative basename. Schema files and output YAML accessed via absolute paths resolved from the schema folder.


### PR DESCRIPTION
## Summary

Five focused fixes from code review, each in its own commit:

- **#105** `load.py update_api_from_package` — replace the buggy `changed = False` reset-each-iteration loop with `changed = any(current_row.get(k) != v for k, v in row.items())` so any field difference triggers an update (previous code only reflected the last field compared).
- **#106** `model.py` FK field generation — generated SQLModel `Field(...)` calls for foreign keys now include `index=True` so joins and FK filters on the generated app are not full table scans.
- **#107** `templates/app_header.py.jinja2` API key check — replace `api_key != _API_KEY` with `secrets.compare_digest(api_key or "", _API_KEY)` and add `import secrets` to the template, removing a timing side channel.
- **#108** `load.py` URL construction — `requests_post`, `requests_get_all`, `requests_update` now build URLs with `f"{server_url.rstrip('/')}/{endpoint}/..."` instead of `os.path.join`, which on POSIX collapses `https://` to `https:/`.
- **#109** `load.py requests_get_all` — initialize `r = None` before the `try`, guard `finally: r.close()` with `if r is not None`, avoiding `UnboundLocalError` when the `session.get(...)` call itself raises.

## Test plan

- [x] Full test suite (`pytest`) — 90/90 pass
- [ ] Manual smoke: `uvicorn app:app` against generated app, verify `/excel/import` round-trip
- [ ] Spot-check generated `models.py` has `index=True` on FK fields