### PR TITLE
fix(#110, #115, #111): fail-closed auth, safe tempfiles, async excel endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ For each schema resource, the generated app exposes the following endpoints (rep
 |----------|---------|-------------|
 | `DATABASE_URL` | `sqlite:///database.db` | Database connection URL (overrides SQLite default) |
 | `ALLOWED_ORIGINS` | `*` | Comma-separated CORS allowed origins |
-| `API_KEY` | *(unset)* | If set, all requests require `X-API-Key: <value>` header |
+| `API_KEY` | *(required)* | All requests require `X-API-Key: <value>` header. App refuses to start if unset unless `ALLOW_NO_AUTH=true` is also set. |
+| `ALLOW_NO_AUTH` | *(unset)* | Set to `true` to start the app without `API_KEY` (dev only — logs a warning, do not use in production) |
 | `SCHEMA_FOLDER` | `.` | Path to `*.schema.yaml` files (used by Excel import/export) |
 | `API_URL` | `http://localhost:8000` | Base URL of this app (used by Excel export) |
 
@@ -169,7 +170,7 @@ Items are grouped by priority. Checked items are complete.
 - [ ] Database migrations via [Alembic](https://alembic.sqlalchemy.org/) instead of `create_all`
 - [x] Configuration management — accept settings via environment variables or a config file (database URL, allowed origins, etc.)
 - [x] CORS and security headers in generated `app.py`
-- [x] API key / token authentication ([FastAPI security](https://fastapi.tiangolo.com/tutorial/security/first-steps/))
+- [x] API key / token authentication ([FastAPI security](https://fastapi.tiangolo.com/tutorial/security/first-steps/)) — fail-closed: app refuses to start unless `API_KEY` is set or `ALLOW_NO_AUTH=true` is explicitly opted in
 - [x] Pagination on list endpoints
 - [x] Proper HTTP error responses with consistent JSON error bodies
 

--- a/fastapifromfrictionless/templates/app_header.py.jinja2
+++ b/fastapifromfrictionless/templates/app_header.py.jinja2
@@ -1,10 +1,13 @@
 
 # app.py
+import asyncio
+import logging
 import os
 import secrets
 import tempfile
+from contextlib import asynccontextmanager
 from pathlib import Path
-from fastapi import Depends, FastAPI, File, HTTPException, Query, Security, UploadFile
+from fastapi import BackgroundTasks, Depends, FastAPI, File, HTTPException, Query, Security, UploadFile
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
@@ -19,8 +22,11 @@ from .database import create_db_and_tables, engine
 from .models import *
 from sqlalchemy.ext.asyncio import AsyncSession
 
-# API key auth — set API_KEY env var to enable; leave unset to disable (dev mode)
+logger = logging.getLogger(__name__)
+
+# API key auth — API_KEY env var is required; set ALLOW_NO_AUTH=true to opt out (dev only)
 _API_KEY = os.getenv("API_KEY", "")
+_ALLOW_NO_AUTH = os.getenv("ALLOW_NO_AUTH", "").lower() in ("1", "true")
 _api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
 async def verify_api_key(api_key: str = Security(_api_key_header)):
@@ -33,8 +39,19 @@ async def verify_api_key(api_key: str = Security(_api_key_header)):
 SCHEMA_FOLDER = os.getenv("SCHEMA_FOLDER", ".")
 API_URL = os.getenv("API_URL", "http://localhost:8000")
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    if not _API_KEY and not _ALLOW_NO_AUTH:
+        raise RuntimeError(
+            "API_KEY env var is not set. Set API_KEY to enable auth, or set ALLOW_NO_AUTH=true to run without authentication."
+        )
+    if _ALLOW_NO_AUTH and not _API_KEY:
+        logger.warning("ALLOW_NO_AUTH=true: API is running without authentication. Do not use in production.")
+    create_db_and_tables()
+    yield
+
 # Initiate app
-app = FastAPI(dependencies=[Depends(verify_api_key)])
+app = FastAPI(lifespan=lifespan, dependencies=[Depends(verify_api_key)])
 
 # CORS — restrict origins via ALLOWED_ORIGINS env var (comma-separated), default open for dev
 _origins = os.getenv("ALLOWED_ORIGINS", "*").split(",")
@@ -72,38 +89,52 @@ def validation_exception_handler(request, exc):
         content={"error": "Validation error", "detail": exc.errors()},
     )
 
-# Dependencies
-@app.on_event('startup')
-def on_startup():
-    create_db_and_tables()
-
 def get_session():
     with Session(engine) as session:
         yield session
 
 # Excel file endpoints
 @app.get('/excel/export', response_class=FileResponse)
-def export_excel():
+async def export_excel(background_tasks: BackgroundTasks):
     from fastapifromfrictionless.load import dump_to_excel
-    tmp = tempfile.mktemp(suffix='.xlsx')
-    dump_to_excel(api_url=API_URL, schema_folder=SCHEMA_FOLDER, output_filepath=tmp, api_key=_API_KEY)
+    with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+        tmp_path = tmp.name
+    await asyncio.to_thread(
+        dump_to_excel,
+        api_url=API_URL,
+        schema_folder=SCHEMA_FOLDER,
+        output_filepath=tmp_path,
+        api_key=_API_KEY,
+    )
+    background_tasks.add_task(os.unlink, tmp_path)
     return FileResponse(
-        tmp,
+        tmp_path,
         media_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
         filename='export.xlsx',
     )
 
 @app.post('/excel/import')
-def import_excel(file: UploadFile = File(...)):
+async def import_excel(file: UploadFile = File(...), background_tasks: BackgroundTasks = None):
     from fastapifromfrictionless.load import create_package, update_api_from_package
-    content = file.file.read()
-    with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False, dir=SCHEMA_FOLDER) as tmp:
+    content = await file.read()
+    with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
         tmp.write(content)
         excel_path = tmp.name
     excel_stem = Path(excel_path).stem
-    create_package(folder=SCHEMA_FOLDER, filename=excel_path)
+    await asyncio.to_thread(create_package, folder=SCHEMA_FOLDER, filename=excel_path)
     package_file = str(Path(SCHEMA_FOLDER) / f'{excel_stem}.package.yaml')
-    update_api_from_package(api_url=API_URL, package_file=package_file, api_key=_API_KEY)
+    try:
+        await asyncio.to_thread(
+            update_api_from_package,
+            api_url=API_URL,
+            package_file=package_file,
+            api_key=_API_KEY,
+        )
+    finally:
+        os.unlink(excel_path)
+        package_yaml = Path(SCHEMA_FOLDER) / f'{excel_stem}.package.yaml'
+        if package_yaml.exists():
+            package_yaml.unlink()
     return {'status': 'imported', 'filename': file.filename}
 
 # @app.get('/')

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,13 @@
+## fix/security-and-background-tasks-110-111-115
+
+Three template-level fixes to the generated FastAPI app, all in `app_header.py.jinja2`:
+
+- #110: fail-closed API key auth. Replaced the deprecated `@app.on_event('startup')` handler with an `@asynccontextmanager` `lifespan` wired into `FastAPI(lifespan=lifespan, ...)`. The lifespan raises `RuntimeError` at startup when `API_KEY` is unset; set `ALLOW_NO_AUTH=true` to explicitly run without auth (logs a warning). Prevents new deployments from silently coming up wide open.
+- #115: safer temp file handling for `/excel/export` and `/excel/import`. Replaced `tempfile.mktemp()` (TOCTOU race, never deleted) with `NamedTemporaryFile(delete=False)` plus a `background_tasks.add_task(os.unlink, tmp_path)` cleanup. The import handler no longer writes uploads into `SCHEMA_FOLDER`; it uses the system temp dir and cleans up both the upload and the generated `.package.yaml` in a `finally` block.
+- #111: `/excel/export` and `/excel/import` are now `async def` and offload the blocking `dump_to_excel`, `create_package`, and `update_api_from_package` calls via `asyncio.to_thread(...)` so the event loop is not stalled during long Excel I/O.
+
+Added `tests/test_security_and_background.py` (21 tests) that assert the generated app contains the new lifespan/imports/async patterns and does not contain the deprecated `on_event('startup')`, `tempfile.mktemp`, or `dir=SCHEMA_FOLDER` patterns.
+
 ## fix/quick-wins-105-109
 
 Fixed 5 code-review quick wins in parallel via feature-team:

--- a/tests/test_security_and_background.py
+++ b/tests/test_security_and_background.py
@@ -1,0 +1,174 @@
+"""Tests for the security + background-task changes in the app_header template.
+
+Covers issues #110 (fail-closed auth), #115 (tempfile cleanup), and #111
+(background-task offloading of excel endpoints).
+"""
+
+import textwrap
+
+import pytest
+
+from fastapifromfrictionless import app
+
+
+def write_schema(tmp_path, name, content):
+    (tmp_path / f"{name}.schema.yaml").write_text(textwrap.dedent(content))
+
+
+@pytest.fixture()
+def simple_folder(tmp_path):
+    write_schema(
+        tmp_path,
+        "location",
+        """\
+        fields:
+          - name: id
+            type: integer
+          - name: address
+            type: string
+        primaryKey:
+          - id
+    """,
+    )
+    return tmp_path
+
+
+def _saved(simple_folder, tmp_path):
+    out = tmp_path / "app.py"
+    app(str(simple_folder)).build().save(out)
+    return out.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Issue #110 — fail-closed auth via lifespan
+# ---------------------------------------------------------------------------
+
+
+def test_lifespan_context_manager_defined(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "@asynccontextmanager" in content
+    assert "async def lifespan(app: FastAPI):" in content
+
+
+def test_lifespan_imports_present(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "from contextlib import asynccontextmanager" in content
+    assert "import logging" in content
+
+
+def test_lifespan_wired_into_app(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "FastAPI(lifespan=lifespan" in content
+
+
+def test_lifespan_raises_when_api_key_missing(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "raise RuntimeError" in content
+    assert "API_KEY env var is not set" in content
+
+
+def test_allow_no_auth_env_var_consulted(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "_ALLOW_NO_AUTH" in content
+    assert 'os.getenv("ALLOW_NO_AUTH"' in content
+
+
+def test_allow_no_auth_logs_warning(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "logger.warning" in content
+    assert "ALLOW_NO_AUTH=true" in content
+
+
+def test_deprecated_on_event_startup_removed(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "@app.on_event('startup')" not in content
+    assert "@app.on_event(\"startup\")" not in content
+
+
+def test_create_db_and_tables_called_in_lifespan(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    # create_db_and_tables() should still run — now from inside lifespan
+    assert "create_db_and_tables()" in content
+
+
+# ---------------------------------------------------------------------------
+# Issue #115 — temp file handling
+# ---------------------------------------------------------------------------
+
+
+def test_deprecated_mktemp_removed(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "tempfile.mktemp" not in content
+
+
+def test_export_uses_named_temporary_file(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "tempfile.NamedTemporaryFile(suffix='.xlsx'" in content
+
+
+def test_export_schedules_temp_file_cleanup(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "background_tasks.add_task(os.unlink" in content
+
+
+def test_import_does_not_write_to_schema_folder(simple_folder, tmp_path):
+    """The upload should land in the system temp dir, not SCHEMA_FOLDER."""
+    content = _saved(simple_folder, tmp_path)
+    # The NamedTemporaryFile for the upload must not pin dir=SCHEMA_FOLDER
+    assert "NamedTemporaryFile(suffix='.xlsx', delete=False, dir=SCHEMA_FOLDER)" not in content
+
+
+def test_import_cleans_up_excel_in_finally(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "finally:" in content
+    assert "os.unlink(excel_path)" in content
+
+
+def test_import_cleans_up_generated_package_yaml(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert ".package.yaml" in content
+    assert "package_yaml.unlink()" in content
+
+
+# ---------------------------------------------------------------------------
+# Issue #111 — background tasks / asyncio.to_thread
+# ---------------------------------------------------------------------------
+
+
+def test_asyncio_imported(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "import asyncio" in content
+
+
+def test_background_tasks_imported(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "BackgroundTasks" in content
+
+
+def test_export_handler_is_async(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "async def export_excel" in content
+
+
+def test_export_offloads_to_thread(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "asyncio.to_thread(" in content
+    assert "dump_to_excel" in content
+
+
+def test_import_handler_is_async(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    assert "async def import_excel" in content
+
+
+def test_import_offloads_update_api_to_thread(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    # update_api_from_package must run on a worker thread, not the event loop
+    assert "asyncio.to_thread(" in content
+    assert "update_api_from_package" in content
+
+
+def test_import_reads_upload_with_await(simple_folder, tmp_path):
+    content = _saved(simple_folder, tmp_path)
+    # Async handler should `await file.read()` rather than block on file.file.read()
+    assert "await file.read()" in content


### PR DESCRIPTION
## Summary

Three template-level fixes to the generated FastAPI app, all in `fastapifromfrictionless/templates/app_header.py.jinja2`:

- **#110 — fail-closed auth.** Replaced the deprecated `@app.on_event('startup')` hook with an `@asynccontextmanager` `lifespan` wired into `FastAPI(lifespan=lifespan, ...)`. The lifespan raises `RuntimeError` if `API_KEY` is unset, and explicitly setting `ALLOW_NO_AUTH=true` is now required to run without auth (logs a warning). New deployments will no longer come up wide open by default.
- **#115 — safe temp file handling.** Swapped `tempfile.mktemp()` (TOCTOU race; never deleted) in `/excel/export` for `NamedTemporaryFile(delete=False)` plus `background_tasks.add_task(os.unlink, tmp_path)`. The `/excel/import` upload now lands in the system temp dir (not `SCHEMA_FOLDER`), and the upload + generated `.package.yaml` are cleaned up in a `finally` block.
- **#111 — non-blocking excel endpoints.** `/excel/export` and `/excel/import` are now `async def` and offload `dump_to_excel`, `create_package`, and `update_api_from_package` via `asyncio.to_thread(...)` so long Excel I/O does not block the event loop.

Closes #110, #115, #111.

## Test plan
- [x] All 90 existing tests still pass
- [x] 21 new tests in `tests/test_security_and_background.py` cover: lifespan + RuntimeError + ALLOW_NO_AUTH warning, no `tempfile.mktemp`, `NamedTemporaryFile` + background cleanup, upload not pinned to `SCHEMA_FOLDER`, `finally`/`unlink` of upload + `.package.yaml`, async handlers, `asyncio.to_thread` for both blocking calls, `await file.read()`
- [x] `pytest tests/ -x -q` → 111 passed