### PR TITLE
fix(podman): parameterize subnet via SUBNET_BASE to prevent host conflicts

### DIFF
--- a/podman/.env.example
+++ b/podman/.env.example
@@ -6,6 +6,9 @@ PROJECT_NAME=my-project
 # NGINX_IP must be unique per simultaneous deployment on this machine.
 # Linux supports the full 127.0.0.0/8 range — use 127.0.1.1, 127.0.1.2, etc.
 NGINX_IP=127.0.1.1
+# SUBNET_BASE must be unique per simultaneous deployment on this machine.
+# Use 10.91, 10.92, 10.93, etc. for each concurrent project.
+SUBNET_BASE=10.91
 
 # PostgreSQL credentials
 POSTGRES_USER=postgres

--- a/podman/compose.yaml
+++ b/podman/compose.yaml
@@ -23,7 +23,7 @@ services:
       - ${NGINX_IP:-127.0.1.1}:5432:5432
     networks:
       app_network:
-        ipv4_address: 10.91.0.5
+        ipv4_address: ${SUBNET_BASE:-10.91}.0.5
         aliases:
           - postgres
     healthcheck:
@@ -44,7 +44,7 @@ services:
         condition: service_healthy
     networks:
       app_network:
-        ipv4_address: 10.91.0.6
+        ipv4_address: ${SUBNET_BASE:-10.91}.0.6
         aliases:
           - pgadmin
 
@@ -67,7 +67,7 @@ services:
         condition: service_healthy
     networks:
       app_network:
-        ipv4_address: 10.91.0.7
+        ipv4_address: ${SUBNET_BASE:-10.91}.0.7
         aliases:
           - api
 
@@ -88,7 +88,7 @@ services:
       - pgadmin
     networks:
       app_network:
-        ipv4_address: 10.91.0.8
+        ipv4_address: ${SUBNET_BASE:-10.91}.0.8
         aliases:
           - nginx
 
@@ -97,6 +97,6 @@ networks:
     driver: bridge
     ipam:
       config:
-        - subnet: 10.91.0.0/16
-          ip_range: 10.91.0.0/24
-          gateway: 10.91.0.1
+        - subnet: ${SUBNET_BASE:-10.91}.0.0/16
+          ip_range: ${SUBNET_BASE:-10.91}.0.0/24
+          gateway: ${SUBNET_BASE:-10.91}.0.1


### PR DESCRIPTION
Closes #123

## Summary

- `podman/compose.yaml` hardcoded `10.91.0.0/16` for the network subnet, IP range, gateway, and all four service static IPs — causing Podman to fail with "subnet already in use" when another deployment on the same host owns that range
- Introduces `SUBNET_BASE` (default `10.91`) so each concurrent deployment can use a distinct two-octet prefix, mirroring the existing `NGINX_IP` pattern
- Documents `SUBNET_BASE` in `podman/.env.example` with the same "must be unique per simultaneous deployment" guidance
- The `:-10.91` fallback means existing deployments with no `SUBNET_BASE` in `.env` continue to work unchanged

## Test plan

- [ ] Set `SUBNET_BASE=10.92` in `.env` on a host where `10.91.0.0/16` is already in use
- [ ] Run `./setup.sh` — Podman should create the network without a subnet conflict error
- [ ] Confirm all services are healthy: `podman-compose ps`
- [ ] Verify that omitting `SUBNET_BASE` from `.env` still works (falls back to `10.91`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)