### PR TITLE
fix(#129): dependency audit — remove redundant/misclassified packages, add Windows install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,30 @@ An ASGI server such as [uvicorn](https://www.uvicorn.org/) is required to run th
 ## Installation
 
 ```bash
-pip install -e .
+pip install fastapifromfrictionless
 ```
+
+For environments that run the **generated app** (FK query endpoints, geo field types):
+
+```bash
+pip install "fastapifromfrictionless[app]"
+```
+
+### Windows
+
+The base install works on Windows without any prerequisites.
+
+The `[app]` extra includes `geoalchemy2`, which requires **GDAL**. If your schemas use geographic field types, install GDAL first:
+
+> [GDAL installation guide for Windows](https://github.com/djayepro3/gdal-easy-installation-guide-windows-linux-macos/blob/main/README.md#%EF%B8%8F-installation-on-windows)
+
+Then install the extra:
+
+```bash
+pip install "fastapifromfrictionless[app]"
+```
+
+If your schemas do not use geo fields, `pip install fastapifromfrictionless` is sufficient and no GDAL install is needed.
 
 ## Quick Start
 

--- a/fastapifromfrictionless/__init__.py
+++ b/fastapifromfrictionless/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.18"
+__version__ = "0.2.19"
 
 import logging
 

--- a/fastapifromfrictionless/runtime/excel.py
+++ b/fastapifromfrictionless/runtime/excel.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 def empty_excel(schema_folder, output_filepath):
     schemas = [file for file in os.listdir(schema_folder) if file.endswith("schema.yaml")]
 
-    with pd.ExcelWriter(output_filepath) as writer:
+    with pd.ExcelWriter(output_filepath, engine='xlsxwriter') as writer:
         logger.info(
             f"Writing empty excel file ({output_filepath}) based on schemas in {schema_folder}."
         )
@@ -110,7 +110,7 @@ def dump_to_excel(
     if api_key:
         session.headers.update({"x-api-key": api_key})
 
-    with pd.ExcelWriter(output_filepath) as writer:
+    with pd.ExcelWriter(output_filepath, engine='xlsxwriter') as writer:
         logger.info(f"Dumping API data to {output_filepath}")
         for schema_file in schemas:
             name = schema_file.replace(".schema.yaml", "")

--- a/podman/Dockerfile
+++ b/podman/Dockerfile
@@ -19,28 +19,22 @@ RUN mkdir -p /generator/api && \
 
 # Stage 2 — lean runtime image
 #
-# Installs only the packages needed to serve the generated FastAPI app.
-# frictionless[generate] and jinja2 are excluded — code generation already
-# happened in Stage 1.
+# [app] extra adds fastapi_querybuilder (FK query endpoints) and geoalchemy2
+# (geo field types). uvicorn and psycopg2-binary are server/DB deps not in
+# the package itself.
 FROM python:3.12-slim
 ARG PACKAGE_VERSION
 WORKDIR /app
 RUN if [ -n "$PACKAGE_VERSION" ]; then \
       pip install --no-cache-dir \
-        "fastapifromfrictionless==${PACKAGE_VERSION}" \
+        "fastapifromfrictionless[app]==${PACKAGE_VERSION}" \
         "uvicorn[standard]" \
-        psycopg2-binary \
-        geoalchemy2 \
-        python-multipart \
-        "frictionless[excel]"; \
+        psycopg2-binary; \
     else \
       pip install --no-cache-dir \
-        fastapifromfrictionless \
+        "fastapifromfrictionless[app]" \
         "uvicorn[standard]" \
-        psycopg2-binary \
-        geoalchemy2 \
-        python-multipart \
-        "frictionless[excel]"; \
+        psycopg2-binary; \
     fi
 COPY --from=generator /generator/api/ /app/api/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,17 +21,17 @@ dependencies = [
     "pandas",
     "SQLmodel",
     "FastAPI",
-    "fastapi_querybuilder",
-    "sqlalchemy",
     "xlsxwriter",
-    "geoalchemy2",
     "python-multipart",
     "frictionless[excel]",
 ]
 
 [project.optional-dependencies]
+app = [
+    "fastapi_querybuilder",
+    "geoalchemy2",
+]
 generate = [
-    "frictionless",
     "jinja2",
 ]
 dev = [
@@ -39,7 +39,6 @@ dev = [
     "ruff",
     "mypy",
     "openpyxl",
-    "frictionless",
     "jinja2",
 ]
 

--- a/reference/dev_notes.md
+++ b/reference/dev_notes.md
@@ -1,3 +1,13 @@
+## v0.2.19 — Dependency audit: remove redundant/misclassified packages (2026-06-05)
+
+- Remove `sqlalchemy` from core (redundant — SQLModel already requires it)
+- Remove `geoalchemy2` from core → add to new `[app]` optional extra (never imported by the package itself; requires GDAL on Windows which blocked clean install)
+- Remove `fastapi_querybuilder` from core → add to `[app]` extra (never imported by the package itself, only emitted into generated app.py)
+- Remove duplicate `frictionless` from `[generate]` and `[dev]` extras (already in core as `frictionless[excel]`)
+- `podman/Dockerfile` Stage 2 now installs `fastapifromfrictionless[app]` instead of listing packages individually
+- Pin `engine="xlsxwriter"` on both `pd.ExcelWriter` calls in `runtime/excel.py` to prevent silent openpyxl fallback and `AttributeError` on `.autofit()`
+- Add Windows installation section to README with GDAL guidance and link
+
 ## v0.2.18 — Fix NameError in generated app (2026-06-03)
 
 Remove `background_tasks: BackgroundTasks = None` from `import_excel` signature — `BackgroundTasks` was dropped from imports in v0.2.17 but left in the function signature, causing `NameError` at startup in all generated apps. Also removes dead imports `from sqlalchemy import text` and `from sqlalchemy.ext.asyncio import AsyncSession` from the generated `app.py`.

--- a/windows-test/oem/deploy/Dockerfile
+++ b/windows-test/oem/deploy/Dockerfile
@@ -19,28 +19,22 @@ RUN mkdir -p /generator/api && \
 
 # Stage 2 — lean runtime image
 #
-# Installs only the packages needed to serve the generated FastAPI app.
-# frictionless[generate] and jinja2 are excluded — code generation already
-# happened in Stage 1.
+# [app] extra adds fastapi_querybuilder (FK query endpoints) and geoalchemy2
+# (geo field types). uvicorn and psycopg2-binary are server/DB deps not in
+# the package itself.
 FROM python:3.12-slim
 ARG PACKAGE_VERSION
 WORKDIR /app
 RUN if [ -n "$PACKAGE_VERSION" ]; then \
       pip install --no-cache-dir \
-        "fastapifromfrictionless==${PACKAGE_VERSION}" \
+        "fastapifromfrictionless[app]==${PACKAGE_VERSION}" \
         "uvicorn[standard]" \
-        psycopg2-binary \
-        geoalchemy2 \
-        python-multipart \
-        "frictionless[excel]"; \
+        psycopg2-binary; \
     else \
       pip install --no-cache-dir \
-        fastapifromfrictionless \
+        "fastapifromfrictionless[app]" \
         "uvicorn[standard]" \
-        psycopg2-binary \
-        geoalchemy2 \
-        python-multipart \
-        "frictionless[excel]"; \
+        psycopg2-binary; \
     fi
 COPY --from=generator /generator/api/ /app/api/
 


### PR DESCRIPTION
## Summary

- **Remove `sqlalchemy`** from core — fully redundant, SQLModel already requires it
- **Remove `geoalchemy2`** from core → new `[app]` optional extra — never imported by the package; requires GDAL on Windows, blocking `pip install` for Windows users
- **Remove `fastapi_querybuilder`** from core → `[app]` optional extra — never imported by the package, only emitted into generated `app.py`
- **Remove duplicate `frictionless`** from `[generate]` and `[dev]` extras — already in core as `frictionless[excel]`
- **`podman/Dockerfile`** Stage 2 simplified to `fastapifromfrictionless[app]` + `uvicorn` + `psycopg2-binary`
- **`excel.py`** — pin `engine='xlsxwriter'` on both `pd.ExcelWriter` calls to prevent silent fallback to openpyxl and `AttributeError` on `.autofit()`
- **`README.md`** — new Windows installation section explaining base install vs `[app]` extra, with GDAL guide link for geo field support

## Impact

`pip install fastapifromfrictionless` on Windows now works cleanly with no prerequisites. Users who need geo fields or FK query endpoints in generated apps install `pip install "fastapifromfrictionless[app]"` and, on Windows, GDAL first.

## Test plan

- [ ] `pip install fastapifromfrictionless` in a clean venv — succeeds, no GDAL required
- [ ] `pip install "fastapifromfrictionless[app]"` — installs fastapi_querybuilder + geoalchemy2
- [ ] `docker compose build api` in `podman/` — Stage 2 uses `[app]` extra, succeeds
- [ ] `pytest` — all tests pass
- [ ] `GET /excel/export` — xlsxwriter engine used, `.autofit()` works

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)